### PR TITLE
Dev codecov ignore tests folder

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,4 +25,4 @@ comment:
   require_changes: no
 
 ignore:
-  - "squidDrone/tests/**/*
+  - "squidDrone/tests/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,6 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "squidDrone/tests/**/*


### PR DESCRIPTION
Like discussed. Completely "tests" folder is excluded now.
See result here: https://codecov.io/gh/elheck/Squiddrone/branch/dev_codecov_ignore_tests_folder