### PR TITLE
Dev save only tagged releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ deploy:
     on:
       tags: true
   - provider: pages
-    skip_cleanup: true
+    cleanup: true
     local_dir: ./squidDrone/build/doc_doxygen/html
     github_token: $GITHUB_TOKEN
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ deploy:
   - provider: releases
     api_key: $GITHUB_TOKEN
     file: "./squidDrone/build/SquidDrone.bin"
-    skip_cleanup: true
+    cleanup: true
     overwrite: true
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ deploy:
     api_key: $GITHUB_TOKEN
     file: "./squidDrone/build/SquidDrone.bin"
     skip_cleanup: true
-    draft: true
+    overwrite: true
     on:
-      all_branches: true
+      tags: true
   - provider: pages
     skip_cleanup: true
     local_dir: ./squidDrone/build/doc_doxygen/html


### PR DESCRIPTION
Closes #174 

Tagged builds are saved. All others not.
Also updated .travis.yml to latest standard, cause skip_cleanup is deprecated.