### PR TITLE
Dev add alltests target

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![badge](https://report.ci/status/elheck/Squiddrone/badge.svg?branch=dev)](https://report.ci/status/elheck/Squiddrone?branch=dev)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/elheck/Squiddrone/tree/dev) 
 
-
 # Squiddrone
 
 Squiddrone is a project for an autonomous flying swarm of drones.

--- a/run_all_unittests.sh
+++ b/run_all_unittests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd squidDrone || exit
+cd build_unittests || exit
+
+make all_tests

--- a/squidDrone/cmake/BundleAllTests.cmake
+++ b/squidDrone/cmake/BundleAllTests.cmake
@@ -1,0 +1,15 @@
+function(SETUP_ALLTESTS_TARGET)
+
+    set(options NONE)
+    set(oneValueArgs NAME)
+    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(AllTests "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Setup target
+    add_custom_target(${AllTests_NAME}
+        # Run tests
+        COMMAND ${AllTests_EXECUTABLE} ${AllTests_EXECUTABLE_ARGS}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${AllTests_DEPENDENCIES}
+    )
+endfunction()

--- a/squidDrone/tests/CMakeLists.txt
+++ b/squidDrone/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 include(AddGoogleTest)
+include(BundleAllTests)
 
 macro(package_add_test TESTNAME)
     add_executable(${TESTNAME} ${ARGN})
@@ -25,13 +26,20 @@ package_add_test(concrete_esc_little_bee_20_a
 )
 target_compile_definitions(concrete_esc_little_bee_20_a PRIVATE STM32G431xx)
 
+SETUP_ALLTESTS_TARGET(
+    NAME all_tests                 
+    EXECUTABLE GTEST_COLOR=1 ctest --verbose -j ${n_cores}
+    DEPENDENCIES
+        euclidean_vector
+        abstract_esc
+        concrete_esc_little_bee_20_a
+)
+
 if(CODE_COVERAGE)
     SETUP_TARGET_FOR_COVERAGE_LCOV(
         NAME coverage                 
         EXECUTABLE ctest -j ${n_cores} # Executable in PROJECT_BINARY_DIR
         DEPENDENCIES
-            euclidean_vector
-            abstract_esc
-            concrete_esc_little_bee_20_a
+            all_tests
     )
 endif(CODE_COVERAGE)


### PR DESCRIPTION
Closes #164 

See AC.
See also added "run_all_unittests.sh" for faster execution of all unittests at once.
See also better Buildoutput on Travis in comparison to e.g. dev branch. -> Unittests outputs are now color highlighted and better readable.