### PR TITLE
Add of doxygen documentation generator v0.6.0

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,3 +6,4 @@ vscode:
     - twxs.cmake@0.0.16:Ors8azcKj0Dx8fExuf6W6w==
     - austin.code-gnu-global@0.2.2:kA6Ik9bhcpAnHk4Q3DsKvw==
     - ms-vscode.cpptools@0.27.0-insiders3:Djj3Csw0GXjmueWAPWvTsg==
+    - cschlosser.doxdocgen@0.6.0:K7ZYJirQpXHMueWxP26Flg==


### PR DESCRIPTION
Closes #196 

Adds doxygen documentation generator plugin in v0.6.0 to gitpod.