### PR TITLE
Add of .clang-format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,10 +12,6 @@ indent_size = 4
 [CMakeLists.*]
 indent_size = 4
 
-[*.h,*.c,*.hpp,*.cpp]
-indent_size = 2
-curly_bracket_next_line = false
-
 [*.md]
 indent_size = 2
 

--- a/squidDrone/.clang-format
+++ b/squidDrone/.clang-format
@@ -1,0 +1,4 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 0


### PR DESCRIPTION
Closes #222 
On different Platforms, VSCode behaves differently. This issue should adjust VSCode for every platform (Linux, Mac, Windows), so that VSCode uses Google Styleguide for "Format Document" with cpp.

VSCode settings for "C_Cpp: Clang_format_style" should be on standard (file)