### PR TITLE
Enable simple switching between different CMake toolchains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.gitignore.io/api/c,c++,eclipse
 # Edit at https://www.gitignore.io/?templates=c,c++,eclipse
 
@@ -144,7 +143,6 @@ local.properties
 
 Debug/
 Release/
-build/
-build_unittests/
+build*/
 
 # End of https://www.gitignore.io/api/c,c++,eclipse

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image: thorshamster/squiddrone:1.2
 
 vscode:
   extensions:
-    - ms-vscode.cmake-tools@1.3.1:Yde58UUl5J9XpLmXM+Bqiw==
+    - ms-vscode.cmake-tools@1.4.1:SXfYiUwB07188Cqeu95dhg==
     - twxs.cmake@0.0.16:Ors8azcKj0Dx8fExuf6W6w==
     - austin.code-gnu-global@0.2.2:kA6Ik9bhcpAnHk4Q3DsKvw==
     - ms-vscode.cpptools@0.27.0-insiders3:Djj3Csw0GXjmueWAPWvTsg==

--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,10 +1,13 @@
 [
   {
     "name": "armgcc_toolchain",
-    "toolchainFile": "../cmake/gnu_arm_stm32_toolchain.cmake"
+    "toolchainFile": "${workspaceFolder}/cmake/gnu_arm_stm32_toolchain.cmake"
   },
   {
     "name": "unittest_toolchain",
-    "toolchainFile": "../cmake/gcc_linux_toolchain.cmake"
+    "toolchainFile": "${workspaceFolder}/cmake/gcc_linux_toolchain.cmake",
+    "cmakeSettings": {
+      "GOOGLE_TESTS": "ON"
+    }
   }
 ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,6 +78,7 @@
     "bit": "cpp",
     "clock_config.h": "c"
   },
+  "cmake.buildDirectory": "${workspaceFolder}/build_${buildKit}-${buildType}",
   "cmake.configureOnOpen": true,
   "editor.formatOnSave": true,
 }


### PR DESCRIPTION
- enable `GOOGLE_TESTS` option by default for `unittest_toolchain`
- build in different build directories  