### PR TITLE
Add of GTEST_SHUFFLE=1 to have shuffling unit test execution

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,7 +79,7 @@ package_add_test(spi_interface
 
 SETUP_ALLTESTS_TARGET(
     NAME all_tests                 
-    EXECUTABLE GTEST_COLOR=1 ctest --verbose -j ${n_cores}
+    EXECUTABLE GTEST_COLOR=1 GTEST_SHUFFLE=1 ctest --verbose -j ${n_cores}
     DEPENDENCIES
         euclidean_vector
         abstract_esc
@@ -98,7 +98,7 @@ SETUP_ALLTESTS_TARGET(
 if(CODE_COVERAGE)
     SETUP_TARGET_FOR_COVERAGE_LCOV(
         NAME coverage                 
-        EXECUTABLE ctest -j ${n_cores} # Executable in PROJECT_BINARY_DIR
+        EXECUTABLE GTEST_SHUFFLE=1 ctest -j ${n_cores}
         DEPENDENCIES
             all_tests
     )


### PR DESCRIPTION
See also https://github.com/google/googletest/blob/master/googletest/docs/advanced.md

Adds GTEST_SHUFFLE=1 to cmake target "all_tests" and "coverage". All unittests are then running in shuffled mode and therefore possible dependencies between the tests can be found.