### PR TITLE
Dev add utilities

### DIFF
--- a/src/imu/CMakeLists.txt
+++ b/src/imu/CMakeLists.txt
@@ -2,6 +2,7 @@ target_include_directories(${ELF_FILE}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/src/i2c
+        ${CMAKE_SOURCE_DIR}/src/utilities
         ${CMAKE_SOURCE_DIR}/tests/mock_libraries/imu
 )
 
@@ -11,4 +12,5 @@ target_sources(${ELF_FILE}
         ${CMAKE_CURRENT_SOURCE_DIR}/gyroscope.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/imu_sensor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/imu_sensor_with_sensitivity.cpp
+        ${CMAKE_SOURCE_DIR}/src/utilities/byte.cpp
 )

--- a/src/imu/imu_sensor.cpp
+++ b/src/imu/imu_sensor.cpp
@@ -80,12 +80,4 @@ auto InertialMeasurementSensor::SetSensorValues(std::int16_t x, std::int16_t y, 
   sensor_values_.z = z;
 }
 
-auto InertialMeasurementSensor::SetBit(std::uint8_t byte, std::uint8_t bit_number_between_0_and_7) noexcept -> std::uint8_t {
-  return byte | 1 << bit_number_between_0_and_7;
-}
-
-auto InertialMeasurementSensor::ClearBit(std::uint8_t byte, std::uint8_t bit_number_between_0_and_7) noexcept -> std::uint8_t {
-  return byte & ~SetBit(0, bit_number_between_0_and_7);
-}
-
 }  // namespace imu

--- a/src/imu/imu_sensor.hpp
+++ b/src/imu/imu_sensor.hpp
@@ -27,8 +27,6 @@ class InertialMeasurementSensor {
   auto ConvertUint8BytesIntoInt16SensorValue(std::uint8_t first_byte, std::uint8_t second_byte) noexcept -> std::int16_t;
   auto IsInitialized(void) noexcept -> bool;
   auto SetSensorValues(std::int16_t x, std::int16_t y, std::int16_t z) noexcept -> void;
-  auto SetBit(std::uint8_t byte, std::uint8_t bit_number) noexcept -> std::uint8_t;
-  auto ClearBit(std::uint8_t byte, std::uint8_t bit_number) noexcept -> std::uint8_t;
 
   types::EuclideanVector<std::int16_t> sensor_values_{-1, -1, -1};
   std::unique_ptr<i2c::I2CInterface> i2c_handler_;

--- a/src/imu/imu_sensor_with_sensitivity.cpp
+++ b/src/imu/imu_sensor_with_sensitivity.cpp
@@ -1,4 +1,5 @@
 #include "imu_sensor_with_sensitivity.hpp"
+#include "utilities/byte.hpp"
 
 namespace imu {
 
@@ -43,23 +44,23 @@ auto InertialMeasurementSensorWithSensitivity::SendSensitivityRegisterData(types
 }
 
 auto InertialMeasurementSensorWithSensitivity::GetConfigRegisterDataForSensitivity(types::ImuSensitivity sensitivity) noexcept -> std::uint8_t {
-  std::uint8_t config_data = ReadContentFromRegister(CONFIG_REGISTER, 1).at(0);
+  utilities::Byte config_data(ReadContentFromRegister(CONFIG_REGISTER, 1).at(0));
 
   if (sensitivity == types::ImuSensitivity::FINEST) {
-    config_data = ClearBit(config_data, 3);
-    config_data = ClearBit(config_data, 4);
+    config_data.ClearBit(3);
+    config_data.ClearBit(4);
   } else if (sensitivity == types::ImuSensitivity::FINER) {
-    config_data = SetBit(config_data, 3);
-    config_data = ClearBit(config_data, 4);
+    config_data.SetBit(3);
+    config_data.ClearBit(4);
   } else if (sensitivity == types::ImuSensitivity::ROUGHER) {
-    config_data = ClearBit(config_data, 3);
-    config_data = SetBit(config_data, 4);
+    config_data.ClearBit(3);
+    config_data.SetBit(4);
   } else if (sensitivity == types::ImuSensitivity::ROUGHEST) {
-    config_data = SetBit(config_data, 3);
-    config_data = SetBit(config_data, 4);
+    config_data.SetBit(3);
+    config_data.SetBit(4);
   }
 
-  return config_data;
+  return config_data.Get();
 }
 
 auto InertialMeasurementSensorWithSensitivity::GetSensitivity(void) noexcept -> types::ImuSensitivity {

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,0 +1,10 @@
+target_include_directories(${ELF_FILE}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/src/utilities
+)
+
+target_sources(${ELF_FILE}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/byte.cpp
+)

--- a/src/utilities/byte.cpp
+++ b/src/utilities/byte.cpp
@@ -6,4 +6,8 @@ auto Byte::Get(void) noexcept -> std::uint8_t {
   return byte_;
 }
 
+auto Byte::SetBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void {
+  byte_ = static_cast<std::uint8_t>(byte_ | 1 << bit_number_between_0_and_7);
+}
+
 }  // namespace utilities

--- a/src/utilities/byte.cpp
+++ b/src/utilities/byte.cpp
@@ -2,7 +2,7 @@
 
 namespace utilities {
 
-auto Byte::Get(void) noexcept -> std ::uint8_t {
+auto Byte::Get(void) noexcept -> std::uint8_t {
   return byte_;
 }
 

--- a/src/utilities/byte.cpp
+++ b/src/utilities/byte.cpp
@@ -1,0 +1,9 @@
+#include "utilities/byte.hpp"
+
+namespace utilities {
+
+auto Byte::Get(void) noexcept -> std ::uint8_t {
+  return byte_;
+}
+
+}  // namespace utilities

--- a/src/utilities/byte.cpp
+++ b/src/utilities/byte.cpp
@@ -7,7 +7,15 @@ auto Byte::Get(void) noexcept -> std::uint8_t {
 }
 
 auto Byte::SetBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void {
-  byte_ = static_cast<std::uint8_t>(byte_ | 1 << bit_number_between_0_and_7);
+  byte_ = SetBitInByte(byte_, bit_number_between_0_and_7);
+}
+
+auto Byte::SetBitInByte(std::uint8_t byte, std::uint8_t bit_number_between_0_and_7) noexcept -> std::uint8_t {
+  return static_cast<std::uint8_t>(byte | 1 << bit_number_between_0_and_7);
+}
+
+auto Byte::ClearBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void {
+  byte_ = static_cast<std::uint8_t>(byte_ & ~SetBitInByte(0, bit_number_between_0_and_7));
 }
 
 }  // namespace utilities

--- a/src/utilities/byte.hpp
+++ b/src/utilities/byte.hpp
@@ -12,6 +12,7 @@ class Byte {
   Byte(){};
   Byte(std::uint8_t byte) : byte_(byte){};
   auto Get(void) noexcept -> std::uint8_t;
+  auto SetBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void;
 
  private:
   std::uint8_t byte_ = 0;

--- a/src/utilities/byte.hpp
+++ b/src/utilities/byte.hpp
@@ -13,8 +13,11 @@ class Byte {
   Byte(std::uint8_t byte) : byte_(byte){};
   auto Get(void) noexcept -> std::uint8_t;
   auto SetBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void;
+  auto ClearBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void;
 
  private:
+  auto SetBitInByte(std::uint8_t byte, std::uint8_t bit_number_between_0_and_7) noexcept -> std::uint8_t;
+
   std::uint8_t byte_ = 0;
 };
 

--- a/src/utilities/byte.hpp
+++ b/src/utilities/byte.hpp
@@ -1,0 +1,22 @@
+#ifndef SRC_UTILITIES_BYTE_HPP_
+#define SRC_UTILITIES_BYTE_HPP_
+
+#include "cstdint"
+
+namespace utilities {
+
+class Byte {
+ public:
+  ~Byte() = default;
+
+  Byte(){};
+  Byte(std::uint8_t byte) : byte_(byte){};
+  auto Get(void) noexcept -> std ::uint8_t;
+
+ private:
+  std::uint8_t byte_ = 0;
+};
+
+}  // namespace utilities
+
+#endif

--- a/src/utilities/byte.hpp
+++ b/src/utilities/byte.hpp
@@ -11,7 +11,7 @@ class Byte {
 
   Byte(){};
   Byte(std::uint8_t byte) : byte_(byte){};
-  auto Get(void) noexcept -> std ::uint8_t;
+  auto Get(void) noexcept -> std::uint8_t;
 
  private:
   std::uint8_t byte_ = 0;

--- a/src/utilities/byte.hpp
+++ b/src/utilities/byte.hpp
@@ -7,10 +7,10 @@ namespace utilities {
 
 class Byte {
  public:
+  Byte() = delete;
   ~Byte() = default;
 
-  Byte(){};
-  Byte(std::uint8_t byte) : byte_(byte){};
+  explicit Byte(std::uint8_t byte) : byte_(byte){};
   auto Get(void) noexcept -> std::uint8_t;
   auto SetBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void;
   auto ClearBit(std::uint8_t bit_number_between_0_and_7) noexcept -> void;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ package_add_test(imu_sensors_gyroscope
     ${CMAKE_SOURCE_DIR}/src/imu/imu_sensor.cpp
     ${CMAKE_SOURCE_DIR}/src/imu/imu_sensor_with_sensitivity.cpp
     ${CMAKE_SOURCE_DIR}/src/imu/gyroscope.cpp
+    ${CMAKE_SOURCE_DIR}/src/utilities/byte.cpp
     ${CMAKE_SOURCE_DIR}/tests/imu/imu_gyroscope_tests.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ macro(package_add_test TESTNAME)
             ${CMAKE_SOURCE_DIR}/src/imu
             ${CMAKE_SOURCE_DIR}/src/i2c
             ${CMAKE_SOURCE_DIR}/src/spi
+            ${CMAKE_SOURCE_DIR}/src/utilities
             ${CMAKE_SOURCE_DIR}/tests/mock_libraries/com
             ${CMAKE_SOURCE_DIR}/tests/mock_libraries/imu
             ${CMAKE_SOURCE_DIR}/tests/mock_libraries/i2c
@@ -82,6 +83,11 @@ package_add_test(imu_sensors_gyroscope
     ${CMAKE_SOURCE_DIR}/src/imu/imu_sensor_with_sensitivity.cpp
     ${CMAKE_SOURCE_DIR}/src/imu/gyroscope.cpp
     ${CMAKE_SOURCE_DIR}/tests/imu/imu_gyroscope_tests.cpp
+)
+
+package_add_test(utilities_byte
+    ${CMAKE_SOURCE_DIR}/src/utilities/byte.cpp
+    ${CMAKE_SOURCE_DIR}/tests/utilities/utilities_byte_tests.cpp
 )
 
 SETUP_ALLTESTS_TARGET(

--- a/tests/utilities/utilities_byte_tests.cpp
+++ b/tests/utilities/utilities_byte_tests.cpp
@@ -62,6 +62,20 @@ TEST_F(UtilityByteTests, byte_init_0_set_three_bits) {
   EXPECT_EQ(0b00101001, unit_under_test_->Get());
 }
 
+TEST_F(UtilityByteTests, byte_init_0_set_three_bits_clear_one) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(0);
+
+  unit_under_test_->SetBit(0);
+  unit_under_test_->SetBit(3);
+  unit_under_test_->SetBit(5);
+
+  EXPECT_EQ(0b00101001, unit_under_test_->Get());
+
+  unit_under_test_->ClearBit(3);
+
+  EXPECT_EQ(0b00100001, unit_under_test_->Get());
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/tests/utilities/utilities_byte_tests.cpp
+++ b/tests/utilities/utilities_byte_tests.cpp
@@ -11,12 +11,6 @@ class UtilityByteTests : public ::testing::Test {
   std::unique_ptr<utilities::Byte> unit_under_test_;
 };
 
-TEST_F(UtilityByteTests, byte_initialize_empty) {
-  unit_under_test_ = std::make_unique<utilities::Byte>();
-
-  EXPECT_EQ(0, unit_under_test_->Get());
-}
-
 TEST_F(UtilityByteTests, byte_initialize_with_number_5) {
   unit_under_test_ = std::make_unique<utilities::Byte>(5);
 

--- a/tests/utilities/utilities_byte_tests.cpp
+++ b/tests/utilities/utilities_byte_tests.cpp
@@ -17,6 +17,36 @@ TEST_F(UtilityByteTests, byte_initialize_empty) {
   EXPECT_EQ(0, unit_under_test_->Get());
 }
 
+TEST_F(UtilityByteTests, byte_initialize_with_number_5) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(5);
+
+  EXPECT_EQ(5, unit_under_test_->Get());
+}
+
+TEST_F(UtilityByteTests, byte_initialize_with_number_0) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(0);
+
+  EXPECT_EQ(0, unit_under_test_->Get());
+}
+
+TEST_F(UtilityByteTests, byte_initialize_with_number_255) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(255);
+
+  EXPECT_EQ(255, unit_under_test_->Get());
+}
+
+TEST_F(UtilityByteTests, byte_initialize_with_number_minus_1) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(-1);
+
+  EXPECT_EQ(0, unit_under_test_->Get());
+}
+
+TEST_F(UtilityByteTests, byte_initialize_with_number_256) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(256);
+
+  EXPECT_EQ(0, unit_under_test_->Get());
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/tests/utilities/utilities_byte_tests.cpp
+++ b/tests/utilities/utilities_byte_tests.cpp
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+#include "utilities/byte.hpp"
+
+namespace {
+
+class UtilityByteTests : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+
+  std::unique_ptr<utilities::Byte> unit_under_test_;
+};
+
+TEST_F(UtilityByteTests, byte_initialize_empty) {
+  unit_under_test_ = std::make_unique<utilities::Byte>();
+
+  EXPECT_EQ(0, unit_under_test_->Get());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/utilities/utilities_byte_tests.cpp
+++ b/tests/utilities/utilities_byte_tests.cpp
@@ -76,6 +76,15 @@ TEST_F(UtilityByteTests, byte_init_0_set_three_bits_clear_one) {
   EXPECT_EQ(0b00100001, unit_under_test_->Get());
 }
 
+TEST_F(UtilityByteTests, byte_init_0_set_bit_9) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(0);
+
+  unit_under_test_->SetBit(3);
+  unit_under_test_->SetBit(9);
+
+  EXPECT_EQ(0b00001000, unit_under_test_->Get());
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/tests/utilities/utilities_byte_tests.cpp
+++ b/tests/utilities/utilities_byte_tests.cpp
@@ -35,6 +35,33 @@ TEST_F(UtilityByteTests, byte_initialize_with_number_255) {
   EXPECT_EQ(255, unit_under_test_->Get());
 }
 
+TEST_F(UtilityByteTests, byte_init_0_set_one_bit) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(0);
+
+  unit_under_test_->SetBit(3);
+
+  EXPECT_EQ(0b00001000, unit_under_test_->Get());
+}
+
+TEST_F(UtilityByteTests, byte_init_0_set_two_bits) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(0);
+
+  unit_under_test_->SetBit(3);
+  unit_under_test_->SetBit(5);
+
+  EXPECT_EQ(0b00101000, unit_under_test_->Get());
+}
+
+TEST_F(UtilityByteTests, byte_init_0_set_three_bits) {
+  unit_under_test_ = std::make_unique<utilities::Byte>(0);
+
+  unit_under_test_->SetBit(0);
+  unit_under_test_->SetBit(3);
+  unit_under_test_->SetBit(5);
+
+  EXPECT_EQ(0b00101001, unit_under_test_->Get());
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/tests/utilities/utilities_byte_tests.cpp
+++ b/tests/utilities/utilities_byte_tests.cpp
@@ -35,18 +35,6 @@ TEST_F(UtilityByteTests, byte_initialize_with_number_255) {
   EXPECT_EQ(255, unit_under_test_->Get());
 }
 
-TEST_F(UtilityByteTests, byte_initialize_with_number_minus_1) {
-  unit_under_test_ = std::make_unique<utilities::Byte>(-1);
-
-  EXPECT_EQ(0, unit_under_test_->Get());
-}
-
-TEST_F(UtilityByteTests, byte_initialize_with_number_256) {
-  unit_under_test_ = std::make_unique<utilities::Byte>(256);
-
-  EXPECT_EQ(0, unit_under_test_->Get());
-}
-
 }  // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Adds first utility function for Bytes.

Manipulation of Bytes will be useful for several packages. Therefore a utility-functionality could be used. This first draft only adds functionality, which will already be used inside of IMU. We may append this in the future will further useful functionalities.

Note: It is not possible to add this branch in codacy. Reason is not known.