### PR TITLE
refactor motorbuilder

### DIFF
--- a/src/propulsion/abstract_motor_builder.hpp
+++ b/src/propulsion/abstract_motor_builder.hpp
@@ -1,0 +1,30 @@
+#ifndef SRC_PROPULSION_ABSTRACT_MOTOR_BUILDER_HPP_
+#define SRC_PROPULSION_ABSTRACT_MOTOR_BUILDER_HPP_
+
+#include <memory>
+#include "motor.hpp"
+#ifndef UNIT_TEST
+#include "propulsion_hardware_config.hpp"
+#else
+#include "propulsion_hardware_config_mock.hpp"
+#endif
+
+namespace propulsion
+
+{
+class AbstractMotorBuilder {
+ public:
+  AbstractMotorBuilder() = default;
+  virtual ~AbstractMotorBuilder() = default;
+  /**
+   * @brief Abstract method to construct a Motor object
+   * 
+   * @param motor_config The information by which it can be determined which Motor to build
+   * @return std::unique_ptr<Motor> A pointer to said Motor. Nullptr on error
+   */
+  virtual auto Create(propulsion::PropulsionHardwareConfig& motor_config) noexcept -> std::unique_ptr<Motor> = 0;
+};
+
+}  // namespace propulsion
+
+#endif

--- a/src/propulsion/motor_builder.hpp
+++ b/src/propulsion/motor_builder.hpp
@@ -2,6 +2,7 @@
 #define SRC_PROPULSION_MOTOR_BUILDER_HPP_
 
 #include <memory>
+#include "abstract_motor_builder.hpp"
 #include "motor.hpp"
 #ifndef UNIT_TEST
 #include "propulsion_hardware_config.hpp"
@@ -12,20 +13,14 @@
 namespace propulsion {
 
 /**
- * @brief A static class which only exists to build a correct Motor object
+ * @brief A class which only exists to build a correct Motor object
  */
-class MotorBuilder {
+class MotorBuilder final : public AbstractMotorBuilder {
  public:
-  /// Constructor is deleted, because it should not be instantiated
-  MotorBuilder() = delete;
+  MotorBuilder() = default;
+  ~MotorBuilder() = default;
 
-  /**
-   * @brief Constructs a Motor object
-   * 
-   * @param motor_config The information by which it can be determined which Motor to build
-   * @return std::unique_ptr<Motor> A pointer to said Motor. Nullptr on error
-   */
-  static auto Create(propulsion::PropulsionHardwareConfig& motor_config) noexcept -> std::unique_ptr<Motor>;
+  auto Create(propulsion::PropulsionHardwareConfig& motor_config) noexcept -> std::unique_ptr<Motor>;
 
  private:
   /**
@@ -35,7 +30,7 @@ class MotorBuilder {
    * @return true if motor config is valid
    * @return false if motor config contains invalid members
    */
-  static auto MotorConfigIsValid(propulsion::PropulsionHardwareConfig& motor_config) noexcept -> const bool;
+  auto MotorConfigIsValid(propulsion::PropulsionHardwareConfig& motor_config) noexcept -> const bool;
 
   /**
    * @brief Get the Correct Esc object from the enum config
@@ -43,7 +38,7 @@ class MotorBuilder {
    * @param config the config struct with information about the Esc and its parameters
    * @return std::unique_ptr<Esc> pointer to ESC 
    */
-  static auto GetCorrectEsc(propulsion::PropulsionHardwareConfig& config) noexcept -> std::unique_ptr<Esc>;
+  auto GetCorrectEsc(propulsion::PropulsionHardwareConfig& config) noexcept -> std::unique_ptr<Esc>;
 };
 }  // namespace propulsion
 #endif

--- a/src/propulsion/motor_builder.hpp
+++ b/src/propulsion/motor_builder.hpp
@@ -20,7 +20,7 @@ class MotorBuilder final : public AbstractMotorBuilder {
   MotorBuilder() = default;
   ~MotorBuilder() = default;
 
-  auto Create(propulsion::PropulsionHardwareConfig& motor_config) noexcept -> std::unique_ptr<Motor>;
+  auto Create(propulsion::PropulsionHardwareConfig& motor_config) noexcept -> std::unique_ptr<Motor> override;
 
  private:
   /**

--- a/tests/propulsion/motorbuilder_test.cpp
+++ b/tests/propulsion/motorbuilder_test.cpp
@@ -22,30 +22,31 @@ class MotorBuilderTest : public ::testing::Test {
 
   propulsion::PropulsionHardwareConfig config;
   TIM_HandleTypeDef timer;
+  propulsion::MotorBuilder unit_under_test = propulsion::MotorBuilder();
 };
 
 //The dynamic upcast is used as a way of having the python function instanceof
 TEST_F(MotorBuilderTest, creates_correct_object) {
-  auto motor_object = propulsion::MotorBuilder::Create(config);
+  auto motor_object = unit_under_test.Create(config);
   auto upcast_object_pointer = dynamic_cast<propulsion::Motor *>(motor_object.get());
   ASSERT_TRUE(upcast_object_pointer != nullptr);
 }
 
 TEST_F(MotorBuilderTest, channel_is_not_in_allowed_channels) {
   config.channel = 666;
-  auto motor_object = propulsion::MotorBuilder::Create(config);
+  auto motor_object = unit_under_test.Create(config);
   ASSERT_EQ(motor_object, nullptr);
 }
 
 TEST_F(MotorBuilderTest, timer_is_nullpointer) {
   config.timer = nullptr;
-  auto motor_object = propulsion::MotorBuilder::Create(config);
+  auto motor_object = unit_under_test.Create(config);
   ASSERT_EQ(motor_object, nullptr);
 }
 
 TEST_F(MotorBuilderTest, esc_is_not_known) {
   config.esc_type = types::EscType::NONE;
-  auto motor_object = propulsion::MotorBuilder::Create(config);
+  auto motor_object = unit_under_test.Create(config);
   ASSERT_EQ(motor_object, nullptr);
 }
 


### PR DESCRIPTION
closes #282 
- Added abstract interface for testing
- Refactored MotorBuilder to be non-static

Acceptance criteria:

- Unit tests cover 100% and all pass
- Unit tests are complete (no logical fallacy is untested and all equivalency classes were tested)
- Propulsion class diagram from wiki is not in conflict with implementation
- All automatic checks pass
- Google Styleguide was followed
- Additional guidelines from the wiki were followed
- No logical errors in code
- All errors are always checked
