### PR TITLE
Dev extend spi interface

### DIFF
--- a/src/spi/CMakeLists.txt
+++ b/src/spi/CMakeLists.txt
@@ -6,4 +6,5 @@ target_include_directories(${ELF_FILE}
 target_sources(${ELF_FILE}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/spi.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/cspin.cpp
 )

--- a/src/spi/cspin.cpp
+++ b/src/spi/cspin.cpp
@@ -1,0 +1,35 @@
+#include "cspin.hpp"
+
+namespace spi {
+
+auto CSPin::SetCS(PinSetting pin_setting) -> void {
+  GPIO_PinState gpio_state = inactive_;
+  if (pin_setting == PinSetting::ACTIVE) {
+    gpio_state = active_;
+  } else {
+    gpio_state = inactive_;
+  }
+
+  HAL_GPIO_WritePin(peripheral_, gpio_pin_, gpio_state);
+}
+
+auto CSPin::SetCSActive() noexcept -> void {
+  SetCS(PinSetting::ACTIVE);
+}
+
+auto CSPin::SetCSInactive() noexcept -> void {
+  SetCS(PinSetting::INACTIVE);
+}
+
+auto CSPin::MapActiveStateToPinSetting() -> void {
+  active_ = GPIO_PIN_RESET;
+  inactive_ = GPIO_PIN_RESET;
+
+  if (active_state_ == CSActiveState::ACTIVE_LOW) {
+    inactive_ = GPIO_PIN_SET;
+  } else {
+    active_ = GPIO_PIN_SET;
+  }
+}
+
+}  // namespace spi

--- a/src/spi/cspin.cpp
+++ b/src/spi/cspin.cpp
@@ -2,7 +2,7 @@
 
 namespace spi {
 
-auto CSPin::SetCS(PinSetting pin_setting) -> void {
+auto CSPin::SetCS(PinSetting pin_setting) noexcept -> void {
   GPIO_PinState gpio_state = inactive_;
 
   if (pin_setting == PinSetting::ACTIVE) {

--- a/src/spi/cspin.cpp
+++ b/src/spi/cspin.cpp
@@ -4,10 +4,9 @@ namespace spi {
 
 auto CSPin::SetCS(PinSetting pin_setting) -> void {
   GPIO_PinState gpio_state = inactive_;
+
   if (pin_setting == PinSetting::ACTIVE) {
     gpio_state = active_;
-  } else {
-    gpio_state = inactive_;
   }
 
   HAL_GPIO_WritePin(peripheral_, gpio_pin_, gpio_state);

--- a/src/spi/cspin.hpp
+++ b/src/spi/cspin.hpp
@@ -1,0 +1,47 @@
+#include "stm32g4xx_hal.h"
+
+namespace spi {
+
+/**
+ * @brief Valid values for chip select pin setting
+ * 
+ */
+enum class PinSetting : bool {
+  ACTIVE = true,
+  INACTIVE = false
+};
+
+/**
+ * @brief Chip select active state setting
+ * 
+ */
+enum class CSActiveState : uint8_t {
+  ACTIVE_LOW = 0,
+  ACTIVE_HIGH
+};
+
+/**
+ * @brief Class to control the chip select GPIO pin
+ * 
+ */
+class CSPin {
+ private:
+  GPIO_TypeDef *peripheral_;
+  uint16_t gpio_pin_;
+  CSActiveState active_state_;
+  GPIO_PinState active_;
+  GPIO_PinState inactive_;
+  auto SetCS(PinSetting pin_setting) noexcept -> void;
+  auto MapActiveStateToPinSetting() -> void;
+
+ public:
+  explicit CSPin(GPIO_TypeDef *peripheral,
+                 uint16_t gpio_pin,
+                 CSActiveState active_state) : peripheral_(peripheral),
+                                               gpio_pin_(gpio_pin),
+                                               active_state_(active_state) { MapActiveStateToPinSetting(); };
+  auto SetCSActive() noexcept -> void;
+  auto SetCSInactive() noexcept -> void;
+};
+
+}  // namespace spi

--- a/src/spi/cspin.hpp
+++ b/src/spi/cspin.hpp
@@ -35,12 +35,30 @@ class CSPin {
   auto MapActiveStateToPinSetting() -> void;
 
  public:
+  /**
+  * @brief Construct a new CSPin object. 
+  * 
+  * @param peripheral Pointer to the GPIO Peripheral that acts as chip select pin.
+  * @param gpio_pin Pin number of the GPIO Peripheral that acts as chip select pin.
+  * @param active_state Can be active high or active low, depending on the necessary SPI configuration.
+  */
   explicit CSPin(GPIO_TypeDef *peripheral,
                  uint16_t gpio_pin,
                  CSActiveState active_state) : peripheral_(peripheral),
                                                gpio_pin_(gpio_pin),
                                                active_state_(active_state) { MapActiveStateToPinSetting(); };
+  /**
+   * @brief Activate the chip select pin. Actual pin value (high or low) depends on the 
+   * selection of active_state.
+   * 
+   */
   auto SetCSActive() noexcept -> void;
+
+  /**
+   * @brief Deactivate the chip select pin. Actual pin value (high or low) depends on the 
+   * selection of active_state.
+   * 
+   */
   auto SetCSInactive() noexcept -> void;
 };
 

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -46,10 +46,20 @@ auto SPI::IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<ui
 }
 
 auto SPI::SetChipSelectPin(PinSetting pin_setting) noexcept -> void {
+  GPIO_PinState pin_state_active = GPIO_PIN_RESET;
+  GPIO_PinState pin_state_inactive = GPIO_PIN_RESET;
   GPIO_PinState pin_state = GPIO_PIN_RESET;
 
-  if (pin_setting == PinSetting::HIGH) {
-    pin_state = GPIO_PIN_SET;
+  if (chip_select_.active_state == CSActiveState::ACTIVE_HIGH) {
+    pin_state_active = GPIO_PIN_SET;
+  } else {
+    pin_state_inactive = GPIO_PIN_SET;
+  }
+
+  if (pin_setting == PinSetting::ACTIVE) {
+    pin_state = pin_state_active;
+  } else {
+    pin_state = pin_state_inactive;
   }
 
   HAL_GPIO_WritePin(chip_select_.peripheral, chip_select_.gpio_pin, pin_state);

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -76,10 +76,9 @@ auto SPI::IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<ui
   return miso_buffer.size() < mosi_buffer.size();
 }
 
-auto SPI::SetChipSelectPin(PinSetting pin_setting) const noexcept -> void {
+auto SPI::GetCSOutputLevel(PinSetting pin_setting) const noexcept -> GPIO_PinState {
   GPIO_PinState pin_state_active = GPIO_PIN_RESET;
   GPIO_PinState pin_state_inactive = GPIO_PIN_RESET;
-  GPIO_PinState pin_state = GPIO_PIN_RESET;
 
   if (chip_select_.active_state == CSActiveState::ACTIVE_HIGH) {
     pin_state_active = GPIO_PIN_SET;
@@ -88,12 +87,21 @@ auto SPI::SetChipSelectPin(PinSetting pin_setting) const noexcept -> void {
   }
 
   if (pin_setting == PinSetting::ACTIVE) {
-    pin_state = pin_state_active;
+    return pin_state_active;
   } else {
-    pin_state = pin_state_inactive;
+    return pin_state_inactive;
+  }
+}
+
+auto SPI::SetChipSelectPin(PinSetting pin_setting) const noexcept -> void {
+  GPIO_PinState gpio_state = GPIO_PIN_RESET;
+  if (pin_setting == PinSetting::ACTIVE) {
+    gpio_state = GetCSOutputLevel(pin_setting);
+  } else {
+    gpio_state = GetCSOutputLevel(pin_setting);
   }
 
-  HAL_GPIO_WritePin(chip_select_.peripheral, chip_select_.gpio_pin, pin_state);
+  HAL_GPIO_WritePin(chip_select_.peripheral, chip_select_.gpio_pin, gpio_state);
 }
 
 }  // namespace spi

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -11,14 +11,14 @@ auto SPI::Write(std::vector<uint8_t> &mosi_data_buffer) noexcept -> types::Drive
     return types::DriverStatus::INPUT_ERROR;
   }
 
-  SetChipSelectPin(PinSetting::ACTIVE);
+  chip_select_.SetCSActive();
 
   transmit_ret_value = HAL_SPI_Transmit(&hspi1,
                                         reinterpret_cast<uint8_t *>(mosi_data_buffer.data()),
                                         transaction_length,
                                         types::SPI_HAL_TX_RX_TIMEOUT);
 
-  SetChipSelectPin(PinSetting::INACTIVE);
+  chip_select_.SetCSInactive();
 
   if (transmit_ret_value == HAL_OK) {
     return_value = types::DriverStatus::OK;
@@ -46,7 +46,7 @@ auto SPI::Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> 
     return types::DriverStatus::INPUT_ERROR;
   }
 
-  SetChipSelectPin(PinSetting::ACTIVE);
+  chip_select_.SetCSActive();
 
   transmit_receive_ret_value = HAL_SPI_TransmitReceive(&hspi1,
                                                        reinterpret_cast<uint8_t *>(mosi_data_buffer.data()),
@@ -54,7 +54,7 @@ auto SPI::Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> 
                                                        transaction_length,
                                                        types::SPI_HAL_TX_RX_TIMEOUT);
 
-  SetChipSelectPin(PinSetting::INACTIVE);
+  chip_select_.SetCSInactive();
 
   if (transmit_receive_ret_value == HAL_OK) {
     return_value = types::DriverStatus::OK;
@@ -74,31 +74,6 @@ auto SPI::IsTransactionLengthExceedingLimits(std::uint8_t transaction_length) no
 
 auto SPI::IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<uint8_t> &miso_buffer) noexcept -> bool {
   return miso_buffer.size() < mosi_buffer.size();
-}
-
-auto SPI::GetCSOutputLevel(PinSetting pin_setting) const noexcept -> GPIO_PinState {
-  GPIO_PinState pin_state_active = GPIO_PIN_RESET;
-  GPIO_PinState pin_state_inactive = GPIO_PIN_RESET;
-
-  if (chip_select_.active_state == CSActiveState::ACTIVE_HIGH) {
-    pin_state_active = GPIO_PIN_SET;
-  } else {
-    pin_state_inactive = GPIO_PIN_SET;
-  }
-
-  if (pin_setting == PinSetting::ACTIVE) {
-    return pin_state_active;
-  } else {
-    return pin_state_inactive;
-  }
-}
-
-auto SPI::SetChipSelectPin(PinSetting pin_setting) const noexcept -> void {
-  GPIO_PinState gpio_state = GPIO_PIN_RESET;
-
-  gpio_state = GetCSOutputLevel(pin_setting);
-
-  HAL_GPIO_WritePin(chip_select_.peripheral, chip_select_.gpio_pin, gpio_state);
 }
 
 }  // namespace spi

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -95,7 +95,7 @@ auto SPI::GetCSOutputLevel(PinSetting pin_setting) const noexcept -> GPIO_PinSta
 
 auto SPI::SetChipSelectPin(PinSetting pin_setting) const noexcept -> void {
   GPIO_PinState gpio_state = GPIO_PIN_RESET;
-  
+
   gpio_state = GetCSOutputLevel(pin_setting);
 
   HAL_GPIO_WritePin(chip_select_.peripheral, chip_select_.gpio_pin, gpio_state);

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -1,11 +1,10 @@
 #include "spi.hpp"
 
 namespace spi {
-auto SPI::Write(std::vector<uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus {
+auto SPI::Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus {
   HAL_StatusTypeDef transmit_ret_value = HAL_ERROR;
-  types::DriverStatus return_value = types::DriverStatus::HAL_ERROR;
 
-  uint8_t transaction_length = static_cast<uint8_t>(mosi_data_buffer.size());
+  std::uint8_t transaction_length = static_cast<std::uint8_t>(mosi_data_buffer.size());
 
   if (IsTransactionLengthExceedingLimits(transaction_length)) {
     return types::DriverStatus::INPUT_ERROR;
@@ -14,33 +13,23 @@ auto SPI::Write(std::vector<uint8_t> &mosi_data_buffer) noexcept -> types::Drive
   chip_select_.SetCSActive();
 
   transmit_ret_value = HAL_SPI_Transmit(&hspi1,
-                                        reinterpret_cast<uint8_t *>(mosi_data_buffer.data()),
+                                        reinterpret_cast<std::uint8_t *>(mosi_data_buffer.data()),
                                         transaction_length,
                                         types::SPI_HAL_TX_RX_TIMEOUT);
 
   chip_select_.SetCSInactive();
 
-  if (transmit_ret_value == HAL_OK) {
-    return_value = types::DriverStatus::OK;
-  }
-  if (transmit_ret_value == HAL_TIMEOUT) {
-    return_value = types::DriverStatus::TIMEOUT;
-  }
-  if (transmit_ret_value == HAL_ERROR) {
-    return_value = types::DriverStatus::HAL_ERROR;
-  }
-  return return_value;
+  return CheckHALReturnValue(transmit_ret_value);
 }
 
-auto SPI::Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus {
-  HAL_StatusTypeDef transmit_receive_ret_value = HAL_ERROR;
-  types::DriverStatus return_value = types::DriverStatus::HAL_ERROR;
+auto SPI::Transfer(std::vector<std::uint8_t> &mosi_data_buffer, std::vector<std::uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus {
+  HAL_StatusTypeDef transmit_receive_ret_value = HAL_StatusTypeDef::HAL_ERROR;
 
   if (IsMisoBufferTooSmall(mosi_data_buffer, miso_data_buffer)) {
     return types::DriverStatus::INPUT_ERROR;
   }
 
-  uint8_t transaction_length = static_cast<uint8_t>(miso_data_buffer.size());
+  std::uint8_t transaction_length = static_cast<std::uint8_t>(miso_data_buffer.size());
 
   if (IsTransactionLengthExceedingLimits(transaction_length)) {
     return types::DriverStatus::INPUT_ERROR;
@@ -49,31 +38,36 @@ auto SPI::Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> 
   chip_select_.SetCSActive();
 
   transmit_receive_ret_value = HAL_SPI_TransmitReceive(&hspi1,
-                                                       reinterpret_cast<uint8_t *>(mosi_data_buffer.data()),
-                                                       reinterpret_cast<uint8_t *>(miso_data_buffer.data()),
+                                                       reinterpret_cast<std::uint8_t *>(mosi_data_buffer.data()),
+                                                       reinterpret_cast<std::uint8_t *>(miso_data_buffer.data()),
                                                        transaction_length,
                                                        types::SPI_HAL_TX_RX_TIMEOUT);
 
   chip_select_.SetCSInactive();
 
-  if (transmit_receive_ret_value == HAL_OK) {
-    return_value = types::DriverStatus::OK;
-  }
-  if (transmit_receive_ret_value == HAL_TIMEOUT) {
-    return_value = types::DriverStatus::TIMEOUT;
-  }
-  if (transmit_receive_ret_value == HAL_ERROR) {
-    return_value = types::DriverStatus::HAL_ERROR;
-  }
-  return return_value;
+  return CheckHALReturnValue(transmit_receive_ret_value);
 }
 
 auto SPI::IsTransactionLengthExceedingLimits(std::uint8_t transaction_length) noexcept -> bool {
   return transaction_length > types::SPI_TRANSACTION_LENGTH_LIMIT;
 }
 
-auto SPI::IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<uint8_t> &miso_buffer) noexcept -> bool {
+auto SPI::IsMisoBufferTooSmall(std::vector<std::uint8_t> &mosi_buffer, std::vector<std::uint8_t> &miso_buffer) noexcept -> bool {
   return miso_buffer.size() < mosi_buffer.size();
+}
+
+auto SPI::CheckHALReturnValue(HAL_StatusTypeDef hal_return_value) -> types::DriverStatus {
+  types::DriverStatus return_value = types::DriverStatus::HAL_ERROR;
+  if (hal_return_value == HAL_OK) {
+    return_value = types::DriverStatus::OK;
+  }
+  if (hal_return_value == HAL_TIMEOUT) {
+    return_value = types::DriverStatus::TIMEOUT;
+  }
+  if (hal_return_value == HAL_ERROR) {
+    return_value = types::DriverStatus::HAL_ERROR;
+  }
+  return return_value;
 }
 
 }  // namespace spi

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -1,6 +1,37 @@
 #include "spi.hpp"
 
 namespace spi {
+auto SPI::Write(std::vector<uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus {
+  HAL_StatusTypeDef transmit_ret_value = HAL_ERROR;
+  types::DriverStatus return_value = types::DriverStatus::HAL_ERROR;
+
+  uint8_t transaction_length = static_cast<uint8_t>(mosi_data_buffer.size());
+
+  if (IsTransactionLengthExceedingLimits(transaction_length)) {
+    return types::DriverStatus::INPUT_ERROR;
+  }
+
+  SetChipSelectPin(PinSetting::ACTIVE);
+
+  transmit_ret_value = HAL_SPI_Transmit(&hspi1,
+                                        reinterpret_cast<uint8_t *>(mosi_data_buffer.data()),
+                                        transaction_length,
+                                        types::SPI_HAL_TX_RX_TIMEOUT);
+
+  SetChipSelectPin(PinSetting::INACTIVE);
+
+  if (transmit_ret_value == HAL_OK) {
+    return_value = types::DriverStatus::OK;
+  }
+  if (transmit_ret_value == HAL_TIMEOUT) {
+    return_value = types::DriverStatus::TIMEOUT;
+  }
+  if (transmit_ret_value == HAL_ERROR) {
+    return_value = types::DriverStatus::HAL_ERROR;
+  }
+  return return_value;
+}
+
 auto SPI::Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus {
   HAL_StatusTypeDef transmit_receive_ret_value = HAL_ERROR;
   types::DriverStatus return_value = types::DriverStatus::HAL_ERROR;
@@ -45,7 +76,7 @@ auto SPI::IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<ui
   return miso_buffer.size() < mosi_buffer.size();
 }
 
-auto SPI::SetChipSelectPin(PinSetting pin_setting) noexcept -> void {
+auto SPI::SetChipSelectPin(PinSetting pin_setting) const noexcept -> void {
   GPIO_PinState pin_state_active = GPIO_PIN_RESET;
   GPIO_PinState pin_state_inactive = GPIO_PIN_RESET;
   GPIO_PinState pin_state = GPIO_PIN_RESET;

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -95,11 +95,8 @@ auto SPI::GetCSOutputLevel(PinSetting pin_setting) const noexcept -> GPIO_PinSta
 
 auto SPI::SetChipSelectPin(PinSetting pin_setting) const noexcept -> void {
   GPIO_PinState gpio_state = GPIO_PIN_RESET;
-  if (pin_setting == PinSetting::ACTIVE) {
-    gpio_state = GetCSOutputLevel(pin_setting);
-  } else {
-    gpio_state = GetCSOutputLevel(pin_setting);
-  }
+  
+  gpio_state = GetCSOutputLevel(pin_setting);
 
   HAL_GPIO_WritePin(chip_select_.peripheral, chip_select_.gpio_pin, gpio_state);
 }

--- a/src/spi/spi.cpp
+++ b/src/spi/spi.cpp
@@ -15,7 +15,7 @@ auto SPI::Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> 
     return types::DriverStatus::INPUT_ERROR;
   }
 
-  SetChipSelectPin(PinSetting::HIGH);
+  SetChipSelectPin(PinSetting::ACTIVE);
 
   transmit_receive_ret_value = HAL_SPI_TransmitReceive(&hspi1,
                                                        reinterpret_cast<uint8_t *>(mosi_data_buffer.data()),
@@ -23,7 +23,7 @@ auto SPI::Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> 
                                                        transaction_length,
                                                        types::SPI_HAL_TX_RX_TIMEOUT);
 
-  SetChipSelectPin(PinSetting::LOW);
+  SetChipSelectPin(PinSetting::INACTIVE);
 
   if (transmit_receive_ret_value == HAL_OK) {
     return_value = types::DriverStatus::OK;

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -26,14 +26,14 @@ class SPI final : spi::SPIInterface {
   virtual ~SPI() = default;
 
   auto Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus override;
-  auto Transfer(std::vector<std::uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus override;
+  auto Transfer(std::vector<std::uint8_t> &mosi_data_buffer, std::vector<std::uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus override;
 
  private:
   CSPin &chip_select_;
 
   auto IsTransactionLengthExceedingLimits(std::uint8_t transaction_length) noexcept -> bool;
-
-  auto IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<uint8_t> &miso_buffer) noexcept -> bool;
+  auto IsMisoBufferTooSmall(std::vector<std::uint8_t> &mosi_buffer, std::vector<std::uint8_t> &miso_buffer) noexcept -> bool;
+  auto CheckHALReturnValue(HAL_StatusTypeDef hal_return_value) -> types::DriverStatus;
 };
 
 }  // namespace spi

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -58,7 +58,7 @@ class SPI final : spi::SPIInterface {
 
   auto IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<uint8_t> &miso_buffer) noexcept -> bool;
 
-  auto SetChipSelectPin(PinSetting pin_state) const noexcept -> void;
+  auto SetChipSelectPin(PinSetting pin_setting) const noexcept -> void;
 
   auto GetCSOutputLevel(PinSetting pin_setting) const noexcept -> GPIO_PinState;
 };

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -49,6 +49,7 @@ class SPI final : spi::SPIInterface {
   explicit SPI(const CSPin chip_select) : spi::SPIInterface(), chip_select_(chip_select) { SetChipSelectPin(PinSetting::INACTIVE); };
   virtual ~SPI() = default;
 
+  auto Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus override;
   auto Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus override;
 
  private:
@@ -79,7 +80,7 @@ class SPI final : spi::SPIInterface {
    * @param pin_state The desired pin state. High or low.
    * @return void
    */
-  auto SetChipSelectPin(PinSetting pin_state) noexcept -> void;
+  auto SetChipSelectPin(PinSetting pin_state) const noexcept -> void;
 };
 
 }  // namespace spi

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -6,7 +6,11 @@
 #include "stm32g4xx_hal.h"
 
 //preserve include order
+#ifndef UNIT_TEST
 #include "cspin.hpp"
+#else
+#include "cspin_mock.hpp"
+#endif
 #include "spi_config.h"
 
 namespace spi {
@@ -18,14 +22,14 @@ namespace spi {
 class SPI final : spi::SPIInterface {
  public:
   SPI() = delete;
-  explicit SPI(const CSPin chip_select) : spi::SPIInterface(), chip_select_(chip_select){};
+  explicit SPI(CSPin &chip_select) : spi::SPIInterface(), chip_select_(chip_select){};
   virtual ~SPI() = default;
 
   auto Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus override;
   auto Transfer(std::vector<std::uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus override;
 
  private:
-  CSPin chip_select_;
+  CSPin &chip_select_;
 
   auto IsTransactionLengthExceedingLimits(std::uint8_t transaction_length) noexcept -> bool;
 

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -2,7 +2,6 @@
 #define SRC_SPI_SPI_HPP_
 
 #include <array>
-#include "mcu_settings.h"
 #include "spi_interface.hpp"
 #include "stm32g4xx_hal.h"
 
@@ -50,7 +49,7 @@ class SPI final : spi::SPIInterface {
   virtual ~SPI() = default;
 
   auto Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus override;
-  auto Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus override;
+  auto Transfer(std::vector<std::uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus override;
 
  private:
   CSPin chip_select_;

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -6,37 +6,10 @@
 #include "stm32g4xx_hal.h"
 
 //preserve include order
+#include "cspin.hpp"
 #include "spi_config.h"
 
 namespace spi {
-
-/**
- * @brief Valid values for chip select pin setting
- * 
- */
-enum class PinSetting : bool {
-  ACTIVE = true,
-  INACTIVE = false
-};
-
-/**
- * @brief Chip select active state setting
- * 
- */
-enum class CSActiveState : uint8_t {
-  ACTIVE_LOW = 0,
-  ACTIVE_HIGH
-};
-
-/**
- * @brief Data structure to hold the chip select GPIO information
- * 
- */
-typedef struct CSPinDefinition {
-  GPIO_TypeDef *peripheral;
-  uint16_t gpio_pin;
-  CSActiveState active_state;
-} CSPin;
 
 /**
  * @brief Concrete implementation of the SPI interface.
@@ -45,7 +18,7 @@ typedef struct CSPinDefinition {
 class SPI final : spi::SPIInterface {
  public:
   SPI() = delete;
-  explicit SPI(const CSPin chip_select) : spi::SPIInterface(), chip_select_(chip_select) { SetChipSelectPin(PinSetting::INACTIVE); };
+  explicit SPI(const CSPin chip_select) : spi::SPIInterface(), chip_select_(chip_select){};
   virtual ~SPI() = default;
 
   auto Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus override;
@@ -57,10 +30,6 @@ class SPI final : spi::SPIInterface {
   auto IsTransactionLengthExceedingLimits(std::uint8_t transaction_length) noexcept -> bool;
 
   auto IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<uint8_t> &miso_buffer) noexcept -> bool;
-
-  auto SetChipSelectPin(PinSetting pin_setting) const noexcept -> void;
-
-  auto GetCSOutputLevel(PinSetting pin_setting) const noexcept -> GPIO_PinState;
 };
 
 }  // namespace spi

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -2,6 +2,7 @@
 #define SRC_SPI_SPI_HPP_
 
 #include <array>
+#include "mcu_settings.h"
 #include "spi_interface.hpp"
 #include "stm32g4xx_hal.h"
 
@@ -15,8 +16,17 @@ namespace spi {
  * 
  */
 enum class PinSetting : bool {
-  HIGH = true,
-  LOW = false
+  ACTIVE = true,
+  INACTIVE = false
+};
+
+/**
+ * @brief Chip select active state setting
+ * 
+ */
+enum class CSActiveState : uint8_t {
+  ACTIVE_LOW = 0,
+  ACTIVE_HIGH
 };
 
 /**
@@ -26,6 +36,7 @@ enum class PinSetting : bool {
 typedef struct CSPinDefinition {
   GPIO_TypeDef *peripheral;
   uint16_t gpio_pin;
+  CSActiveState active_state;
 } CSPin;
 
 /**
@@ -35,7 +46,7 @@ typedef struct CSPinDefinition {
 class SPI final : spi::SPIInterface {
  public:
   SPI() = delete;
-  explicit SPI(const CSPin chip_select) : spi::SPIInterface(), chip_select_(chip_select){};
+  explicit SPI(const CSPin chip_select) : spi::SPIInterface(), chip_select_(chip_select) { SetChipSelectPin(PinSetting::INACTIVE); };
   virtual ~SPI() = default;
 
   auto Transfer(std::vector<uint8_t> &mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus override;

--- a/src/spi/spi.hpp
+++ b/src/spi/spi.hpp
@@ -54,32 +54,13 @@ class SPI final : spi::SPIInterface {
  private:
   CSPin chip_select_;
 
-  /**
-   * @brief Check if transaction length is exceeding maximum size.
-   * 
-   * @param transaction_length Transaction length in bytes.
-   * @return true Transaction length is exceeding limits.
-   * @return false Transaction length is within limits.
-   */
   auto IsTransactionLengthExceedingLimits(std::uint8_t transaction_length) noexcept -> bool;
 
-  /**
-   * @brief Check if miso buffer is smaller than the mosi buffer.
-   * 
-   * @param mosi_buffer Reference to the mosi buffer.
-   * @param miso_buffer Reference to the miso buffer
-   * @return true Miso buffer is too small
-   * @return false Miso buffer is large enough.
-   */
   auto IsMisoBufferTooSmall(std::vector<uint8_t> &mosi_buffer, std::vector<uint8_t> &miso_buffer) noexcept -> bool;
 
-  /**
-   * @brief Set the Chip select GPIO pin.
-   * 
-   * @param pin_state The desired pin state. High or low.
-   * @return void
-   */
   auto SetChipSelectPin(PinSetting pin_state) const noexcept -> void;
+
+  auto GetCSOutputLevel(PinSetting pin_setting) const noexcept -> GPIO_PinState;
 };
 
 }  // namespace spi

--- a/src/spi/spi_interface.hpp
+++ b/src/spi/spi_interface.hpp
@@ -35,19 +35,12 @@ class SPIInterface {
   virtual auto Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus = 0;
 
   /**
-   * @brief Perform an SPI Read transaction.
-   * 
-   * @param miso_data_buffer Reference to buffer for data reception.
-   * @return types::DriverStatus Status information about the success of the transmission.
-   */
-  virtual auto Read(std::vector<std::uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus = 0;
-
-  /**
    * @brief Perform an SPI Tx/Rx transaction. The transaction is bidirectional. While MOSI data are transmitted, the incoming MISO data are 
    * stored in the miso_data_buffer. The maximum length of any SPI transaction is limited to a maximum length defined in
    * SPI_TRANSACTION_LENGTH_LIMIT.
    * @param mosi_data_buffer Reference to buffer holding the data to be transmitted. Has to be provided by the caller.
    * @param miso_data_buffer Reference to buffer for received data. Has to be provided by the caller. Must be at least as big as mosi_data_buffer.
+   * In case of a read action, miso data buffer length can be used to force the transfer length.
    * @return types::DriverStatus Status information about the success of the transmission. Possible values: 
    * -OK - Transaction finished without errors.
    * -HAL_ERROR - HAL function returned an error status

--- a/src/spi/spi_interface.hpp
+++ b/src/spi/spi_interface.hpp
@@ -27,6 +27,22 @@ class SPIInterface {
   virtual ~SPIInterface() = default;
 
   /**
+   * @brief Perform an SPI Write transaction. MISO data are disregarded.
+   * 
+   * @param mosi_data_buffer Reference to buffer holding the data to be transmitted.
+   * @return types::DriverStatus Status information about the success of the transmission.
+   */
+  virtual auto Write(std::vector<std::uint8_t> &mosi_data_buffer) noexcept -> types::DriverStatus = 0;
+
+  /**
+   * @brief Perform an SPI Read transaction.
+   * 
+   * @param miso_data_buffer Reference to buffer for data reception.
+   * @return types::DriverStatus Status information about the success of the transmission.
+   */
+  virtual auto Read(std::vector<std::uint8_t> &miso_data_buffer) noexcept -> types::DriverStatus = 0;
+
+  /**
    * @brief Perform an SPI Tx/Rx transaction. The transaction is bidirectional. While MOSI data are transmitted, the incoming MISO data are 
    * stored in the miso_data_buffer. The maximum length of any SPI transaction is limited to a maximum length defined in
    * SPI_TRANSACTION_LENGTH_LIMIT.

--- a/tests/spi/CMakeLists.txt
+++ b/tests/spi/CMakeLists.txt
@@ -21,3 +21,16 @@ add_testpackage(TEST_NAME
                     ${CMAKE_SOURCE_DIR}/src/types
                     ${CMAKE_SOURCE_DIR}/tests/spi/mock_libraries
 )
+
+add_testpackage(TEST_NAME 
+                    cspin
+                SOURCES 
+                    cspin_tests.cpp
+                    ${CMAKE_SOURCE_DIR}/src/spi/cspin.cpp
+                    ${CMAKE_SOURCE_DIR}/tests/spi/mock_libraries/gpio_config.c
+                    ${CMAKE_SOURCE_DIR}/tests/spi/mock_libraries/stm32g4xx_hal.c
+                TEST_INCLUDE_DIRECTORIES 
+                    ${CMAKE_SOURCE_DIR}/src/spi
+                    ${CMAKE_SOURCE_DIR}/src/types
+                    ${CMAKE_SOURCE_DIR}/tests/spi/mock_libraries
+)

--- a/tests/spi/cspin_tests.cpp
+++ b/tests/spi/cspin_tests.cpp
@@ -1,0 +1,51 @@
+#include "cspin.hpp"
+#include "gtest/gtest.h"
+
+namespace {
+
+class CSPinTests : public ::testing::Test {
+ protected:
+  std::unique_ptr<spi::CSPin> unit_under_test_;
+};
+}  // namespace
+
+TEST_F(CSPinTests, active_high_set_cs) {
+  GPIO_TypeDef mock_gpio_typedef;
+  mock_gpio_typedef.mock_test_value = GPIO_PIN_RESET;
+
+  unit_under_test_ = std::make_unique<spi::CSPin>(&mock_gpio_typedef, 0, spi::CSActiveState::ACTIVE_HIGH);
+  unit_under_test_->SetCSActive();
+  EXPECT_EQ(mock_gpio_typedef.mock_test_value, (GPIO_PinState)GPIO_PinState::GPIO_PIN_SET);
+}
+
+TEST_F(CSPinTests, active_high_reset_cs) {
+  GPIO_TypeDef mock_gpio_typedef;
+  mock_gpio_typedef.mock_test_value = GPIO_PIN_SET;
+
+  unit_under_test_ = std::make_unique<spi::CSPin>(&mock_gpio_typedef, 0, spi::CSActiveState::ACTIVE_HIGH);
+  unit_under_test_->SetCSInactive();
+  EXPECT_EQ(mock_gpio_typedef.mock_test_value, (GPIO_PinState)GPIO_PinState::GPIO_PIN_RESET);
+}
+
+TEST_F(CSPinTests, active_low_set_cs) {
+  GPIO_TypeDef mock_gpio_typedef;
+  mock_gpio_typedef.mock_test_value = GPIO_PIN_RESET;
+
+  unit_under_test_ = std::make_unique<spi::CSPin>(&mock_gpio_typedef, 0, spi::CSActiveState::ACTIVE_LOW);
+  unit_under_test_->SetCSActive();
+  EXPECT_EQ(mock_gpio_typedef.mock_test_value, (GPIO_PinState)GPIO_PinState::GPIO_PIN_RESET);
+}
+
+TEST_F(CSPinTests, active_low_reset_cs) {
+  GPIO_TypeDef mock_gpio_typedef;
+  mock_gpio_typedef.mock_test_value = GPIO_PIN_SET;
+
+  unit_under_test_ = std::make_unique<spi::CSPin>(&mock_gpio_typedef, 0, spi::CSActiveState::ACTIVE_LOW);
+  unit_under_test_->SetCSInactive();
+  EXPECT_EQ(mock_gpio_typedef.mock_test_value, (GPIO_PinState)GPIO_PinState::GPIO_PIN_SET);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/spi/mock_libraries/cspin_mock.hpp
+++ b/tests/spi/mock_libraries/cspin_mock.hpp
@@ -1,0 +1,19 @@
+#ifndef TESTS_SPI_MOCK_LIBRARIES_CSPIN_MOCK_HPP_
+#define TESTS_SPI_MOCK_LIBRARIES_CSPIN_MOCK_HPP_
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "stm32g4xx_hal.h"
+
+namespace spi {
+
+class CSPin {
+ public:
+  CSPin(){};
+  CSPin(const CSPin&){};
+  MOCK_METHOD((void), SetCSActive, (), (noexcept));
+  MOCK_METHOD((void), SetCSInactive, (), (noexcept));
+};
+}  // namespace spi
+
+#endif

--- a/tests/spi/mock_libraries/stm32g4xx_hal.c
+++ b/tests/spi/mock_libraries/stm32g4xx_hal.c
@@ -5,4 +5,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   return hspi->mock_return_value;
 }
 
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint16_t Size,
+                                   uint32_t Timeout) {
+  return hspi->mock_return_value;
+}
+
 void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState) {}

--- a/tests/spi/mock_libraries/stm32g4xx_hal.c
+++ b/tests/spi/mock_libraries/stm32g4xx_hal.c
@@ -10,4 +10,8 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pTxData, ui
   return hspi->mock_return_value;
 }
 
-void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState) {}
+void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState) {
+  if (GPIOx) {
+    GPIOx->mock_test_value = (uint8_t)PinState;
+  }
+}

--- a/tests/spi/mock_libraries/stm32g4xx_hal.h
+++ b/tests/spi/mock_libraries/stm32g4xx_hal.h
@@ -24,7 +24,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
 HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint16_t Size,
                                    uint32_t Timeout);
 
-typedef uint8_t GPIO_TypeDef;
+typedef struct __GPIO_TypeDef {
+  uint8_t mock_test_value;
+} GPIO_TypeDef;
 
 typedef enum {
   GPIO_PIN_RESET = 0U,

--- a/tests/spi/mock_libraries/stm32g4xx_hal.h
+++ b/tests/spi/mock_libraries/stm32g4xx_hal.h
@@ -21,6 +21,9 @@ typedef struct __SPI_HandleTypeDef {
 HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size,
                                           uint32_t Timeout);
 
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint16_t Size,
+                                   uint32_t Timeout);
+
 typedef uint8_t GPIO_TypeDef;
 
 typedef enum {

--- a/tests/spi/spi_interface_tests.cpp
+++ b/tests/spi/spi_interface_tests.cpp
@@ -5,7 +5,10 @@ namespace {
 class ConcreteSPIInterface final : public spi::SPIInterface {
  public:
   explicit ConcreteSPIInterface() : spi::SPIInterface(){};
-  auto Transfer(std::vector<std::uint8_t> &RxData, std::vector<std::uint8_t> &TxData) noexcept -> types::DriverStatus override {
+  auto Write(std::vector<std::uint8_t> &TxData) noexcept -> types::DriverStatus override {
+    return types::DriverStatus::OK;
+  }
+  auto Transfer(std::vector<std::uint8_t> &TxData, std::vector<std::uint8_t> &RxData) noexcept -> types::DriverStatus override {
     return types::DriverStatus::OK;
   };
 };
@@ -19,7 +22,14 @@ TEST_F(SpiInterfaceTests, transfer) {
   auto Rx = std::vector<std::uint8_t>();
   auto Tx = std::vector<std::uint8_t>();
   unit_under_test_ = std::make_unique<ConcreteSPIInterface>();
-  auto rv = unit_under_test_->Transfer(Rx, Tx);
+  auto rv = unit_under_test_->Transfer(Tx, Rx);
+  ASSERT_EQ(rv, types::DriverStatus::OK);
+}
+
+TEST_F(SpiInterfaceTests, write) {
+  auto Tx = std::vector<std::uint8_t>();
+  unit_under_test_ = std::make_unique<ConcreteSPIInterface>();
+  auto rv = unit_under_test_->Write(Tx);
   ASSERT_EQ(rv, types::DriverStatus::OK);
 }
 }  // namespace

--- a/tests/spi/spi_tests.cpp
+++ b/tests/spi/spi_tests.cpp
@@ -10,11 +10,27 @@ class SPITests : public ::testing::Test {
     unit_under_test_ = std::make_unique<spi::SPI>(cs_pin);
   }
 
-  spi::CSPin cs_pin = {.peripheral = nullptr, .gpio_pin = 0};
+  spi::CSPin cs_pin = {.peripheral = nullptr, .gpio_pin = 0, .active_state = spi::CSActiveState::ACTIVE_LOW};
   std::unique_ptr<spi::SPI> unit_under_test_;
   std::vector<uint8_t> miso_buffer;
   std::vector<uint8_t> mosi_buffer;
 };
+
+TEST_F(SPITests, cs_pin_setting_active_low) {
+  GPIO_TypeDef test_mock_gpio_;
+  spi::CSPin cs_pin_ = {.peripheral = &test_mock_gpio_, .gpio_pin = 0, .active_state = spi::CSActiveState::ACTIVE_LOW};
+  auto unit_under_test_ = std::make_unique<spi::SPI>(cs_pin_);
+  unit_under_test_->Transfer(mosi_buffer, miso_buffer);
+  EXPECT_EQ(test_mock_gpio_.mock_test_value, static_cast<uint8_t>(GPIO_PIN_SET));
+}
+
+TEST_F(SPITests, cs_pin_setting_active_high) {
+  GPIO_TypeDef test_mock_gpio_;
+  spi::CSPin cs_pin_ = {.peripheral = &test_mock_gpio_, .gpio_pin = 0, .active_state = spi::CSActiveState::ACTIVE_HIGH};
+  auto unit_under_test_ = std::make_unique<spi::SPI>(cs_pin_);
+  unit_under_test_->Transfer(mosi_buffer, miso_buffer);
+  EXPECT_EQ(test_mock_gpio_.mock_test_value, static_cast<uint8_t>(GPIO_PIN_RESET));
+}
 
 TEST_F(SPITests, transfer_exceeding_buffer_size_limit) {
   std::vector<uint8_t> too_large_buffer(65);

--- a/tests/spi/spi_tests.cpp
+++ b/tests/spi/spi_tests.cpp
@@ -2,6 +2,9 @@
 #include "gtest/gtest.h"
 #include "spi.hpp"
 
+using ::testing::NiceMock;
+using ::testing::Return;
+
 namespace {
 
 class SPITests : public ::testing::Test {
@@ -10,27 +13,12 @@ class SPITests : public ::testing::Test {
     unit_under_test_ = std::make_unique<spi::SPI>(cs_pin);
   }
 
-  spi::CSPin cs_pin = {.peripheral = nullptr, .gpio_pin = 0, .active_state = spi::CSActiveState::ACTIVE_LOW};
+  NiceMock<spi::CSPin> cs_pin;
   std::unique_ptr<spi::SPI> unit_under_test_;
   std::vector<uint8_t> miso_buffer;
   std::vector<uint8_t> mosi_buffer;
 };
-
-TEST_F(SPITests, cs_pin_setting_active_low) {
-  GPIO_TypeDef test_mock_gpio_;
-  spi::CSPin cs_pin_ = {.peripheral = &test_mock_gpio_, .gpio_pin = 0, .active_state = spi::CSActiveState::ACTIVE_LOW};
-  auto unit_under_test_ = std::make_unique<spi::SPI>(cs_pin_);
-  unit_under_test_->Transfer(mosi_buffer, miso_buffer);
-  EXPECT_EQ(test_mock_gpio_.mock_test_value, static_cast<uint8_t>(GPIO_PIN_SET));
-}
-
-TEST_F(SPITests, cs_pin_setting_active_high) {
-  GPIO_TypeDef test_mock_gpio_;
-  spi::CSPin cs_pin_ = {.peripheral = &test_mock_gpio_, .gpio_pin = 0, .active_state = spi::CSActiveState::ACTIVE_HIGH};
-  auto unit_under_test_ = std::make_unique<spi::SPI>(cs_pin_);
-  unit_under_test_->Transfer(mosi_buffer, miso_buffer);
-  EXPECT_EQ(test_mock_gpio_.mock_test_value, static_cast<uint8_t>(GPIO_PIN_RESET));
-}
+}  // namespace
 
 TEST_F(SPITests, transfer_exceeding_buffer_size_limit) {
   std::vector<uint8_t> too_large_buffer(65);
@@ -128,4 +116,7 @@ TEST_F(SPITests, write_spi_hal_busy) {
   EXPECT_EQ(rv, types::DriverStatus::HAL_ERROR);
 }
 
-}  // namespace
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/spi/spi_tests.cpp
+++ b/tests/spi/spi_tests.cpp
@@ -15,35 +15,35 @@ class SPITests : public ::testing::Test {
 
   NiceMock<spi::CSPin> cs_pin;
   std::unique_ptr<spi::SPI> unit_under_test_;
-  std::vector<uint8_t> miso_buffer;
-  std::vector<uint8_t> mosi_buffer;
+  std::vector<std::uint8_t> miso_buffer;
+  std::vector<std::uint8_t> mosi_buffer;
 };
 }  // namespace
 
 TEST_F(SPITests, transfer_exceeding_buffer_size_limit) {
-  std::vector<uint8_t> too_large_buffer(65);
+  std::vector<std::uint8_t> too_large_buffer(65);
   types::DriverStatus rv = unit_under_test_->Transfer(mosi_buffer, too_large_buffer);
   EXPECT_EQ(rv, types::DriverStatus::INPUT_ERROR);
 }
 
 TEST_F(SPITests, transfer_buffer_size_limit_at_maximum) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
-  std::vector<uint8_t> miso_buffer(64);
+  std::vector<std::uint8_t> miso_buffer(64);
   types::DriverStatus rv = unit_under_test_->Transfer(mosi_buffer, miso_buffer);
   EXPECT_EQ(rv, types::DriverStatus::OK);
 }
 
 TEST_F(SPITests, transfer_buffer_size_limit_zero) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
-  std::vector<uint8_t> zero_size_buffer(0);
+  std::vector<std::uint8_t> zero_size_buffer(0);
   types::DriverStatus rv = unit_under_test_->Transfer(zero_size_buffer, miso_buffer);
   EXPECT_EQ(rv, types::DriverStatus::OK);
 }
 
 TEST_F(SPITests, transfer_miso_buffer_too_small) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
-  std::vector<uint8_t> mosi_buffer(5);
-  std::vector<uint8_t> small_miso_buffer(0);
+  std::vector<std::uint8_t> mosi_buffer(5);
+  std::vector<std::uint8_t> small_miso_buffer(0);
   types::DriverStatus rv = unit_under_test_->Transfer(mosi_buffer, small_miso_buffer);
   EXPECT_EQ(rv, types::DriverStatus::INPUT_ERROR);
 }
@@ -73,21 +73,21 @@ TEST_F(SPITests, transfer_spi_hal_busy) {
 }
 
 TEST_F(SPITests, write_exceeding_buffer_size_limit) {
-  std::vector<uint8_t> too_large_buffer(65);
+  std::vector<std::uint8_t> too_large_buffer(65);
   types::DriverStatus rv = unit_under_test_->Write(too_large_buffer);
   EXPECT_EQ(rv, types::DriverStatus::INPUT_ERROR);
 }
 
 TEST_F(SPITests, write_buffer_size_limit_at_maximum) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
-  std::vector<uint8_t> mosi_buffer(64);
+  std::vector<std::uint8_t> mosi_buffer(64);
   types::DriverStatus rv = unit_under_test_->Write(mosi_buffer);
   EXPECT_EQ(rv, types::DriverStatus::OK);
 }
 
 TEST_F(SPITests, write_buffer_size_limit_zero) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
-  std::vector<uint8_t> zero_size_buffer(0);
+  std::vector<std::uint8_t> zero_size_buffer(0);
   types::DriverStatus rv = unit_under_test_->Write(zero_size_buffer);
   EXPECT_EQ(rv, types::DriverStatus::OK);
 }

--- a/tests/spi/spi_tests.cpp
+++ b/tests/spi/spi_tests.cpp
@@ -16,27 +16,27 @@ class SPITests : public ::testing::Test {
   std::vector<uint8_t> mosi_buffer;
 };
 
-TEST_F(SPITests, exceeding_buffer_size_limit) {
+TEST_F(SPITests, transfer_exceeding_buffer_size_limit) {
   std::vector<uint8_t> too_large_buffer(65);
   types::DriverStatus rv = unit_under_test_->Transfer(mosi_buffer, too_large_buffer);
   EXPECT_EQ(rv, types::DriverStatus::INPUT_ERROR);
 }
 
-TEST_F(SPITests, buffer_size_limit_at_maximum) {
+TEST_F(SPITests, transfer_buffer_size_limit_at_maximum) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
   std::vector<uint8_t> miso_buffer(64);
   types::DriverStatus rv = unit_under_test_->Transfer(mosi_buffer, miso_buffer);
   EXPECT_EQ(rv, types::DriverStatus::OK);
 }
 
-TEST_F(SPITests, buffer_size_limit_zero) {
+TEST_F(SPITests, transfer_buffer_size_limit_zero) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
   std::vector<uint8_t> zero_size_buffer(0);
   types::DriverStatus rv = unit_under_test_->Transfer(zero_size_buffer, miso_buffer);
   EXPECT_EQ(rv, types::DriverStatus::OK);
 }
 
-TEST_F(SPITests, miso_buffer_too_small) {
+TEST_F(SPITests, transfer_miso_buffer_too_small) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
   std::vector<uint8_t> mosi_buffer(5);
   std::vector<uint8_t> small_miso_buffer(0);
@@ -44,27 +44,71 @@ TEST_F(SPITests, miso_buffer_too_small) {
   EXPECT_EQ(rv, types::DriverStatus::INPUT_ERROR);
 }
 
-TEST_F(SPITests, successful_spi_transfer) {
+TEST_F(SPITests, transfer_successful_spi_transfer) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
   types::DriverStatus rv = unit_under_test_->Transfer(miso_buffer, mosi_buffer);
   EXPECT_EQ(rv, types::DriverStatus::OK);
 }
 
-TEST_F(SPITests, timeout_during_spi_transfer) {
+TEST_F(SPITests, transfer_timeout_during_spi_transfer) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_TIMEOUT;
   types::DriverStatus rv = unit_under_test_->Transfer(miso_buffer, mosi_buffer);
   EXPECT_EQ(rv, types::DriverStatus::TIMEOUT);
 }
 
-TEST_F(SPITests, spi_hal_error) {
+TEST_F(SPITests, transfer_spi_hal_error) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_ERROR;
   types::DriverStatus rv = unit_under_test_->Transfer(miso_buffer, mosi_buffer);
   EXPECT_EQ(rv, types::DriverStatus::HAL_ERROR);
 }
 
-TEST_F(SPITests, spi_hal_busy) {
+TEST_F(SPITests, transfer_spi_hal_busy) {
   hspi1.mock_return_value = HAL_StatusTypeDef::HAL_BUSY;
   types::DriverStatus rv = unit_under_test_->Transfer(miso_buffer, mosi_buffer);
+  EXPECT_EQ(rv, types::DriverStatus::HAL_ERROR);
+}
+
+TEST_F(SPITests, write_exceeding_buffer_size_limit) {
+  std::vector<uint8_t> too_large_buffer(65);
+  types::DriverStatus rv = unit_under_test_->Write(too_large_buffer);
+  EXPECT_EQ(rv, types::DriverStatus::INPUT_ERROR);
+}
+
+TEST_F(SPITests, write_buffer_size_limit_at_maximum) {
+  hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
+  std::vector<uint8_t> mosi_buffer(64);
+  types::DriverStatus rv = unit_under_test_->Write(mosi_buffer);
+  EXPECT_EQ(rv, types::DriverStatus::OK);
+}
+
+TEST_F(SPITests, write_buffer_size_limit_zero) {
+  hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
+  std::vector<uint8_t> zero_size_buffer(0);
+  types::DriverStatus rv = unit_under_test_->Write(zero_size_buffer);
+  EXPECT_EQ(rv, types::DriverStatus::OK);
+}
+
+TEST_F(SPITests, write_successful_spi_transfer) {
+  hspi1.mock_return_value = HAL_StatusTypeDef::HAL_OK;
+  types::DriverStatus rv = unit_under_test_->Write(mosi_buffer);
+  EXPECT_EQ(rv, types::DriverStatus::OK);
+}
+
+TEST_F(SPITests, write_timeout_during_spi_transfer) {
+  hspi1.mock_return_value = HAL_StatusTypeDef::HAL_TIMEOUT;
+  types::DriverStatus rv = unit_under_test_->Write(mosi_buffer);
+  EXPECT_EQ(rv, types::DriverStatus::TIMEOUT);
+}
+
+TEST_F(SPITests, write_spi_hal_error) {
+  hspi1.mock_return_value = HAL_StatusTypeDef::HAL_ERROR;
+  types::DriverStatus rv = unit_under_test_->Write(mosi_buffer);
+  EXPECT_EQ(rv, types::DriverStatus::HAL_ERROR);
+}
+
+TEST_F(SPITests, write_spi_hal_busy) {
+  hspi1.mock_return_value = HAL_StatusTypeDef::HAL_BUSY;
+  types::DriverStatus rv = unit_under_test_->Write(mosi_buffer);
   EXPECT_EQ(rv, types::DriverStatus::HAL_ERROR);
 }
 


### PR DESCRIPTION
This PR extends SPI capabilities:
- Simple Write operation
- Chip select pin active state is configurable

Acceptance criteria:
- Unit tests cover 100% and all pass
- Unit tests are complete (no logical fallacy is untested and all equivalency classes were tested)
- SPI class diagram from wiki is not in conflict with implementation
- All automatic checks pass
- Google Styleguide was followed
- Additional guidelines from the wiki were followed
- No logical errors in code
- All error return values are always checked

Closes #301 