### PR TITLE
Add of tasks.json for Tasks to build Target and Unittests

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Target",
+      "type": "shell",
+      "command": "./build.sh",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+
+      }
+    },
+    {
+      "label": "Build and run all Unittests",
+      "type": "shell",
+      "command": "./build_unittests.sh && ./run_all_unittests.sh",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #302 

Adds VSCode Tasks for Building Target and Build and run of all Unittests.