### PR TITLE
Dev spi protocol

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -31,6 +31,8 @@
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.2069809071" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.value.g3" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.includepaths.627501505" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/spi}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/i2c}&quot;"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input.397393141" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input"/>
 							</tool>
@@ -50,6 +52,8 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/system/cmsis/dsp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/system}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/spi}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/i2c}&quot;"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.255845699" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>
@@ -73,6 +77,8 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/system/cmsis}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/system}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/spi}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/i2c}&quot;"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.978901079" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>
@@ -98,7 +104,7 @@
 					</folderInfo>
 					<sourceEntries>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="drivers"/>
-						<entry excluding="imu" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="startup"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="system"/>
 					</sourceEntries>
@@ -136,6 +142,8 @@
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.640958511" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.value.g0" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.includepaths.546440533" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.includepaths" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/spi}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/i2c}&quot;"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input.1351391234" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input"/>
 							</tool>
@@ -153,6 +161,8 @@
 									<listOptionValue builtIn="false" value="../Core/Inc"/>
 									<listOptionValue builtIn="false" value="../Drivers/STM32G4xx_HAL_Driver/Inc"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/spi}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/i2c}&quot;"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1040321773" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>
@@ -170,6 +180,8 @@
 									<listOptionValue builtIn="false" value="../Core/Inc"/>
 									<listOptionValue builtIn="false" value="../Drivers/STM32G4xx_HAL_Driver/Inc"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/spi}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SquidDrone/src/i2c}&quot;"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.195154246" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>

--- a/src/com/CMakeLists.txt
+++ b/src/com/CMakeLists.txt
@@ -7,6 +7,5 @@ target_include_directories(${ELF_FILE}
 target_sources(${ELF_FILE}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/com_message_buffer.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/com_nrf24l01.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/com_nrf24l01_spi_protocol.cpp
 )

--- a/src/com/CMakeLists.txt
+++ b/src/com/CMakeLists.txt
@@ -7,4 +7,6 @@ target_include_directories(${ELF_FILE}
 target_sources(${ELF_FILE}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/com_message_buffer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/com_nrf24l01.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/com_nrf24l01_spi_protocol.cpp
 )

--- a/src/com/com_nrf24l01_reg.hpp
+++ b/src/com/com_nrf24l01_reg.hpp
@@ -1,0 +1,283 @@
+#ifndef SRC_COM_COM_NRF24L01_REG_HPP_
+#define SRC_COM_COM_NRF24L01_REG_HPP_
+
+#include <array>
+#include <cstdint>
+
+#ifndef UNIT_TEST
+#include "utilities/byte.hpp"
+#else
+#include "byte_mock.hpp"
+#endif
+
+namespace com {
+
+enum class State : std::uint8_t {
+  disabled = 0,
+  enabled
+};
+
+enum class CRCEncodingScheme : std::uint8_t {
+  crc_8bit,
+  crc_16bit
+};
+
+enum class DataPipe : std::uint8_t {
+  rx_pipe_0 = 0,
+  rx_pipe_1,
+  rx_pipe_2,
+  rx_pipe_3,
+  rx_pipe_4,
+  rx_pipe_5,
+  tx_pipe
+};
+
+enum class DataPipeAddressWidth : std::uint8_t {
+  aw_3bytes = 0x1,
+  aw_4bytes = 0x2,
+  aw_5bytes = 0x3,
+};
+
+enum class AutoRetransmissionDelay : std::uint8_t {
+  // auto retransmis delay 250-4000 us
+  ard250us = 0x0,
+  ard500us = 0x1,
+  ard750us = 0x2,
+  ard1000us = 0x3,
+  ard1250us = 0x4,
+  ard1500us = 0x5,
+  ard1750us = 0x6,
+  ard2000us = 0x7,
+  ard2250us = 0x8,
+  ard2500us = 0x9,
+  ard2750us = 0xa,
+  ard3000us = 0xb,
+  ard3250us = 0xc,
+  ard3500us = 0xd,
+  ard3750us = 0xe,
+  ard4000us = 0xf
+};
+
+enum class AutoRetransmitCount : std::uint8_t {
+  // auto retransmit count 0-15 in case of failed AR
+  arc0 = 0x0,
+  arc1 = 0x1,
+  arc2 = 0x2,
+  arc3 = 0x3,
+  arc4 = 0x4,
+  arc5 = 0x5,
+  arc6 = 0x6,
+  arc7 = 0x7,
+  arc8 = 0x8,
+  arc9 = 0x9,
+  arc10 = 0xa,
+  arc11 = 0xb,
+  arc12 = 0xc,
+  arc13 = 0xd,
+  arc14 = 0xe,
+  arc15 = 0xf
+};
+
+enum class OperationMode : std::uint8_t {
+  prim_rx = 0,
+  prim_tx
+};
+
+enum class RFPowerSetting : std::uint8_t {
+  rf_pwr_18dBm = 0x0,
+  rf_pwr_12dBm = 0x1,
+  rf_pwr_6dBm = 0x2,
+  rf_pwr_0dBm = 0x3
+};
+
+enum class DataRateSetting : std::uint8_t {
+  rf_dr_1mbps = 0,
+  rf_dr_2mbps = 1
+};
+
+using data_pipe_address = std::array<std::uint8_t, 5>;
+using register_t = std::uint8_t;
+
+namespace instruction_word {
+static constexpr std::uint8_t R_REGISTER = 0x00;
+static constexpr std::uint8_t W_REGISTER = 0x20;
+static constexpr std::uint8_t R_RX_PAYLOAD = 0x61;
+static constexpr std::uint8_t W_TX_PAYLOAD = 0xa0;
+static constexpr std::uint8_t FLUSH_TX = 0xe1;
+static constexpr std::uint8_t FLUSH_RX = 0xe2;
+static constexpr std::uint8_t REUSE_TX_PL = 0xe3;
+static constexpr std::uint8_t NOP = 0xff;
+}  // namespace instruction_word
+
+namespace rf_config {
+static constexpr std::uint8_t rf_channel = 20;
+}
+
+namespace reg {
+/// configuration register
+namespace config {
+static constexpr std::uint8_t REG_ADDR = 0x0;
+static constexpr std::uint8_t MASK_RX_DR = 6;
+static constexpr std::uint8_t MASK_TX_DS = 5;
+static constexpr std::uint8_t MASK_MAX_RT = 4;
+static constexpr std::uint8_t EN_CRC = 3;
+static constexpr std::uint8_t CRCO = 2;
+static constexpr std::uint8_t PWR_UP = 1;
+static constexpr std::uint8_t PRIM_RX = 0;
+}  // namespace config
+
+/// enable enhanced shock burst auto acknowledgement
+namespace en_aa {
+static constexpr std::uint8_t REG_ADDR = 0x1;
+static constexpr std::uint8_t ENAA_P5 = 5;
+static constexpr std::uint8_t ENAA_P4 = 4;
+static constexpr std::uint8_t ENAA_P3 = 3;
+static constexpr std::uint8_t ENAA_P2 = 2;
+static constexpr std::uint8_t ENAA_P1 = 1;
+static constexpr std::uint8_t ENAA_P0 = 0;
+}  // namespace en_aa
+
+/// enable RX data pipes
+namespace en_rxaddr {
+static constexpr std::uint8_t REG_ADDR = 0x2;
+static constexpr std::uint8_t ERX_P5 = 5;
+static constexpr std::uint8_t ERX_P4 = 4;
+static constexpr std::uint8_t ERX_P3 = 3;
+static constexpr std::uint8_t ERX_P2 = 2;
+static constexpr std::uint8_t ERX_P1 = 1;
+static constexpr std::uint8_t ERX_P0 = 1;
+}  // namespace en_rxaddr
+
+/// setup of address widths
+namespace setup_aw {
+static constexpr std::uint8_t REG_ADDR = 0x3;
+}  // namespace setup_aw
+
+/// setup of automatic retransmission
+namespace setup_retr {
+static constexpr std::uint8_t REG_ADDR = 0x4;
+}  // namespace setup_retr
+
+/// RF channel setting
+namespace rf_ch {
+static constexpr std::uint8_t REG_ADDR = 0x5;
+}  // namespace rf_ch
+
+/// RF setup register
+namespace rf_setup {
+static constexpr std::uint8_t REG_ADDR = 0x6;
+static constexpr std::uint8_t PLL_LOCK = 4;
+static constexpr std::uint8_t RF_DR = 3;
+static constexpr std::uint8_t RF_PWR = 1;
+static constexpr std::uint8_t LNA_HCURR = 0;
+}  // namespace rf_setup
+
+/// Status Register
+namespace status {
+static constexpr std::uint8_t REG_ADDR = 0x7;
+static constexpr std::uint8_t RX_DR = 6;
+static constexpr std::uint8_t TX_DS = 5;
+static constexpr std::uint8_t MAX_RT = 4;
+static constexpr std::uint8_t RX_P_NO = 1;
+static constexpr std::uint8_t RX_P_NO_0 = 0b0;
+static constexpr std::uint8_t RX_P_NO_1 = 0b1;
+static constexpr std::uint8_t RX_P_NO_2 = 0b10;
+static constexpr std::uint8_t RX_P_NO_3 = 0b11;
+static constexpr std::uint8_t RX_P_NO_4 = 0b100;
+static constexpr std::uint8_t RX_P_NO_5 = 0b101;
+static constexpr std::uint8_t RX_FIFO_EMPTY = 0b111;
+static constexpr std::uint8_t TX_FULL = 0;
+}  // namespace status
+
+/// Transmit observe register
+namespace observe_tx {
+static constexpr std::uint8_t REG_ADDR = 0x8;
+static constexpr std::uint8_t PLOS_CNT = 4;
+static constexpr std::uint8_t ARC_CNT = 0;
+}  // namespace observe_tx
+
+/// Carrier detect
+namespace cd {
+static constexpr std::uint8_t REG_ADDR = 0x9;
+static constexpr std::uint8_t CD = 0;
+}  // namespace cd
+
+/// Receive address data pipe 0. 5 Bytes maximum length.
+namespace rx_addr_p0 {
+static constexpr std::uint8_t REG_ADDR = 0x0a;
+}  // namespace rx_addr_p0
+
+/// Receive address data pipe 1. 5 Bytes maximum length.
+namespace rx_addr_p1 {
+static constexpr std::uint8_t REG_ADDR = 0x0b;
+}  // namespace rx_addr_p1
+
+/// Receive address data pipe 2. Only LSB.
+namespace rx_addr_p2 {
+static constexpr std::uint8_t REG_ADDR = 0x0c;
+}  // namespace rx_addr_p2
+
+/// Receive address data pipe 3. Only LSB.
+namespace rx_addr_p3 {
+static constexpr std::uint8_t REG_ADDR = 0x0d;
+}  // namespace rx_addr_p3
+
+/// Receive address data pipe 4. Only LSB.
+namespace rx_addr_p4 {
+static constexpr std::uint8_t REG_ADDR = 0x0e;
+}  // namespace rx_addr_p4
+
+/// Receive address data pipe 5. Only LSB.
+namespace rx_addr_p5 {
+static constexpr std::uint8_t REG_ADDR = 0x0f;
+}  // namespace rx_addr_p5
+
+/// Transmit address. Used for a PTX device only.
+namespace tx_addr {
+static constexpr std::uint8_t REG_ADDR = 0x10;
+}  // namespace tx_addr
+
+/// Number of bytes in RX payload in data pipe 0.
+namespace rx_pw_p0 {
+static constexpr std::uint8_t REG_ADDR = 0x11;
+}  // namespace rx_pw_p0
+
+/// Number of bytes in RX payload in data pipe 1.
+namespace rx_pw_p1 {
+static constexpr std::uint8_t REG_ADDR = 0x12;
+}  // namespace rx_pw_p1
+
+/// Number of bytes in RX payload in data pipe 2.
+namespace rx_pw_p2 {
+static constexpr std::uint8_t REG_ADDR = 0x13;
+}  // namespace rx_pw_p2
+
+/// Number of bytes in RX payload in data pipe 3.
+namespace rx_pw_p3 {
+static constexpr std::uint8_t REG_ADDR = 0x14;
+}  // namespace rx_pw_p3
+
+/// Number of bytes in RX payload in data pipe 4.
+namespace rx_pw_p4 {
+static constexpr std::uint8_t REG_ADDR = 0x15;
+}  // namespace rx_pw_p4
+
+/// Number of bytes in RX payload in data pipe 5.
+namespace rx_pw_p5 {
+static constexpr std::uint8_t REG_ADDR = 0x16;
+}  // namespace rx_pw_p5
+
+/// FIFO status register
+namespace fifo_status {
+static constexpr std::uint8_t REG_ADDR = 0x17;
+static constexpr std::uint8_t TX_REUSE = 6;
+static constexpr std::uint8_t TX_FULL = 5;
+static constexpr std::uint8_t TX_EMPTY = 4;
+static constexpr std::uint8_t RX_FULL = 1;
+static constexpr std::uint8_t RX_EMPTY = 0;
+}  // namespace fifo_status
+
+}  // namespace reg
+}  // namespace com
+
+#endif

--- a/src/com/com_nrf24l01_reg.hpp
+++ b/src/com/com_nrf24l01_reg.hpp
@@ -4,12 +4,6 @@
 #include <array>
 #include <cstdint>
 
-#ifndef UNIT_TEST
-#include "utilities/byte.hpp"
-#else
-#include "byte_mock.hpp"
-#endif
-
 namespace com {
 
 enum class State : std::uint8_t {

--- a/src/com/com_nrf24l01_reg.hpp
+++ b/src/com/com_nrf24l01_reg.hpp
@@ -33,9 +33,9 @@ enum class DataPipe : std::uint8_t {
 };
 
 enum class DataPipeAddressWidth : std::uint8_t {
-  aw_3bytes = 0x1,
-  aw_4bytes = 0x2,
-  aw_5bytes = 0x3,
+  address_width_3bytes = 0x1,
+  address_width_4bytes = 0x2,
+  address_width_5bytes = 0x3,
 };
 
 enum class AutoRetransmissionDelay : std::uint8_t {
@@ -196,11 +196,11 @@ static constexpr std::uint8_t PLOS_CNT = 4;
 static constexpr std::uint8_t ARC_CNT = 0;
 }  // namespace observe_tx
 
-/// Carrier detect
-namespace cd {
+/// Received power detector register
+namespace rpd {
 static constexpr std::uint8_t REG_ADDR = 0x9;
-static constexpr std::uint8_t CD = 0;
-}  // namespace cd
+static constexpr std::uint8_t RPD = 0;
+}  // namespace rpd
 
 /// Receive address data pipe 0. 5 Bytes maximum length.
 namespace rx_addr_p0 {

--- a/src/com/com_nrf24l01_spi_protocol.cpp
+++ b/src/com/com_nrf24l01_spi_protocol.cpp
@@ -4,8 +4,8 @@
 namespace com {
 
 auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address) noexcept -> std::uint8_t {
-  auto position_in_buffer = 1;
-  auto spi_transfer_length = 2;
+  constexpr auto position_in_buffer = 1;
+  constexpr auto spi_transfer_length = 2;
   std::vector<std::uint8_t> mosi_data_buffer;
   std::vector<std::uint8_t> miso_data_buffer(spi_transfer_length);
   mosi_data_buffer.push_back(instruction_word::R_REGISTER | register_address);
@@ -85,8 +85,8 @@ auto NRF24L01SpiProtocol::FlushRxBuffer() noexcept -> types::DriverStatus {
 }
 
 auto NRF24L01SpiProtocol::ReadAndClearIRQFlags() noexcept -> register_t {
-  auto position_in_buffer = 0;
-  auto spi_transfer_length = 2;
+  constexpr auto position_in_buffer = 0;
+  constexpr auto spi_transfer_length = 2;
   std::vector<std::uint8_t> mosi_data;
   std::vector<std::uint8_t> miso_data(spi_transfer_length);
 

--- a/src/com/com_nrf24l01_spi_protocol.cpp
+++ b/src/com/com_nrf24l01_spi_protocol.cpp
@@ -36,10 +36,10 @@ auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::uint
   return spi_ret_val;
 }
 
-auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vector<uint8_t> register_content) -> types::DriverStatus {
+auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vector<uint8_t> &register_content) -> types::DriverStatus {
   std::vector<uint8_t> mosi_data_buffer;
   mosi_data_buffer = register_content;
-  mosi_data_buffer.insert(mosi_data_buffer.begin(), instruction_word::W_REGISTER);
+  mosi_data_buffer.insert(mosi_data_buffer.begin(), (instruction_word::W_REGISTER | register_address));
 
   auto spi_ret_val = spi_.Write(mosi_data_buffer);
 

--- a/src/com/com_nrf24l01_spi_protocol.cpp
+++ b/src/com/com_nrf24l01_spi_protocol.cpp
@@ -26,7 +26,7 @@ auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address, std:
   return miso_data_buffer;
 }
 
-auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::uint8_t register_content) -> types::DriverStatus {
+auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::uint8_t register_content) noexcept -> types::DriverStatus {
   std::vector<std::uint8_t> mosi_data_buffer;
   mosi_data_buffer.push_back(instruction_word::W_REGISTER | register_address);
   mosi_data_buffer.push_back(register_content);
@@ -36,7 +36,7 @@ auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::uint
   return spi_ret_val;
 }
 
-auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) -> types::DriverStatus {
+auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) noexcept -> types::DriverStatus {
   std::vector<std::uint8_t> mosi_data_buffer;
   mosi_data_buffer = register_content;
   mosi_data_buffer.insert(mosi_data_buffer.begin(), (instruction_word::W_REGISTER | register_address));
@@ -84,7 +84,7 @@ auto NRF24L01SpiProtocol::FlushRxBuffer() noexcept -> types::DriverStatus {
   return spi_ret_val;
 }
 
-auto NRF24L01SpiProtocol::ReadAndClearIRQFlags() -> register_t {
+auto NRF24L01SpiProtocol::ReadAndClearIRQFlags() noexcept -> register_t {
   auto position_in_buffer = 0;
   auto spi_transfer_length = 2;
   std::vector<std::uint8_t> mosi_data;

--- a/src/com/com_nrf24l01_spi_protocol.cpp
+++ b/src/com/com_nrf24l01_spi_protocol.cpp
@@ -15,7 +15,7 @@ auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address) noex
   return miso_data_buffer.at(position_in_buffer);
 }
 
-auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<uint8_t> {
+auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<std::uint8_t> {
   std::vector<std::uint8_t> mosi_data_buffer;
   std::vector<std::uint8_t> miso_data_buffer(length + 1);
   mosi_data_buffer.push_back(instruction_word::R_REGISTER | register_address);
@@ -36,8 +36,8 @@ auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::uint
   return spi_ret_val;
 }
 
-auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vector<uint8_t> &register_content) -> types::DriverStatus {
-  std::vector<uint8_t> mosi_data_buffer;
+auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) -> types::DriverStatus {
+  std::vector<std::uint8_t> mosi_data_buffer;
   mosi_data_buffer = register_content;
   mosi_data_buffer.insert(mosi_data_buffer.begin(), (instruction_word::W_REGISTER | register_address));
 
@@ -46,12 +46,22 @@ auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vect
   return spi_ret_val;
 }
 
-auto NRF24L01SpiProtocol::WritePayloadData(std::vector<uint8_t> &payload) noexcept -> types::DriverStatus {
-  std::vector<uint8_t> mosi_data_buffer;
+auto NRF24L01SpiProtocol::WritePayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus {
+  std::vector<std::uint8_t> mosi_data_buffer;
   mosi_data_buffer = payload;
   mosi_data_buffer.insert(mosi_data_buffer.begin(), instruction_word::W_TX_PAYLOAD);
 
   auto spi_ret_val = spi_.Write(mosi_data_buffer);
+
+  return spi_ret_val;
+}
+
+auto NRF24L01SpiProtocol::ReadPayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus {
+  std::vector<std::uint8_t> mosi_data_buffer;
+  mosi_data_buffer.push_back(instruction_word::R_RX_PAYLOAD);
+
+  auto spi_ret_val = spi_.Transfer(mosi_data_buffer, payload);
+  payload.erase(payload.begin());
 
   return spi_ret_val;
 }

--- a/src/com/com_nrf24l01_spi_protocol.cpp
+++ b/src/com/com_nrf24l01_spi_protocol.cpp
@@ -10,7 +10,7 @@ auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address) noex
   std::vector<std::uint8_t> miso_data_buffer(spi_transfer_length);
   mosi_data_buffer.push_back(instruction_word::R_REGISTER | register_address);
 
-  spi_.Transfer(mosi_data_buffer, miso_data_buffer);
+  spi_->Transfer(mosi_data_buffer, miso_data_buffer);
 
   return miso_data_buffer.at(position_in_buffer);
 }
@@ -20,7 +20,7 @@ auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address, std:
   std::vector<std::uint8_t> miso_data_buffer(length + 1);
   mosi_data_buffer.push_back(instruction_word::R_REGISTER | register_address);
 
-  spi_.Transfer(mosi_data_buffer, miso_data_buffer);
+  spi_->Transfer(mosi_data_buffer, miso_data_buffer);
   miso_data_buffer.erase(miso_data_buffer.begin());
 
   return miso_data_buffer;
@@ -31,7 +31,7 @@ auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::uint
   mosi_data_buffer.push_back(instruction_word::W_REGISTER | register_address);
   mosi_data_buffer.push_back(register_content);
 
-  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+  auto spi_ret_val = spi_->Write(mosi_data_buffer);
 
   return spi_ret_val;
 }
@@ -41,7 +41,7 @@ auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vect
   mosi_data_buffer = register_content;
   mosi_data_buffer.insert(mosi_data_buffer.begin(), (instruction_word::W_REGISTER | register_address));
 
-  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+  auto spi_ret_val = spi_->Write(mosi_data_buffer);
 
   return spi_ret_val;
 }
@@ -51,7 +51,7 @@ auto NRF24L01SpiProtocol::WritePayloadData(std::vector<std::uint8_t> &payload) n
   mosi_data_buffer = payload;
   mosi_data_buffer.insert(mosi_data_buffer.begin(), instruction_word::W_TX_PAYLOAD);
 
-  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+  auto spi_ret_val = spi_->Write(mosi_data_buffer);
 
   return spi_ret_val;
 }
@@ -60,7 +60,7 @@ auto NRF24L01SpiProtocol::ReadPayloadData(std::vector<std::uint8_t> &payload) no
   std::vector<std::uint8_t> mosi_data_buffer;
   mosi_data_buffer.push_back(instruction_word::R_RX_PAYLOAD);
 
-  auto spi_ret_val = spi_.Transfer(mosi_data_buffer, payload);
+  auto spi_ret_val = spi_->Transfer(mosi_data_buffer, payload);
   payload.erase(payload.begin());
 
   return spi_ret_val;
@@ -70,7 +70,7 @@ auto NRF24L01SpiProtocol::FlushTxBuffer() noexcept -> types::DriverStatus {
   std::vector<std::uint8_t> mosi_data_buffer;
   mosi_data_buffer.push_back(instruction_word::FLUSH_TX);
 
-  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+  auto spi_ret_val = spi_->Write(mosi_data_buffer);
 
   return spi_ret_val;
 }
@@ -79,7 +79,7 @@ auto NRF24L01SpiProtocol::FlushRxBuffer() noexcept -> types::DriverStatus {
   std::vector<std::uint8_t> mosi_data_buffer;
   mosi_data_buffer.push_back(instruction_word::FLUSH_RX);
 
-  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+  auto spi_ret_val = spi_->Write(mosi_data_buffer);
 
   return spi_ret_val;
 }
@@ -98,7 +98,7 @@ auto NRF24L01SpiProtocol::ReadAndClearIRQFlags() noexcept -> register_t {
 
   mosi_data.push_back(instruction_word::W_REGISTER | reg::status::REG_ADDR);
   mosi_data.push_back(construct_byte.Get());
-  spi_.Transfer(mosi_data, miso_data);
+  spi_->Transfer(mosi_data, miso_data);
 
   return miso_data.at(position_in_buffer);
 }

--- a/src/com/com_nrf24l01_spi_protocol.cpp
+++ b/src/com/com_nrf24l01_spi_protocol.cpp
@@ -1,0 +1,59 @@
+#include "com_nrf24l01_spi_protocol.hpp"
+#include "com_nrf24l01_reg.hpp"
+
+namespace com {
+
+auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address) noexcept -> std::uint8_t {
+  auto position_in_buffer = 1;
+  auto spi_transfer_length = 2;
+  std::vector<std::uint8_t> mosi_data_buffer;
+  std::vector<std::uint8_t> miso_data_buffer(spi_transfer_length);
+  mosi_data_buffer.push_back(instruction_word::R_REGISTER | register_address);
+
+  spi_.Transfer(mosi_data_buffer, miso_data_buffer);
+
+  return miso_data_buffer.at(position_in_buffer);
+}
+
+auto NRF24L01SpiProtocol::ReadRegister(const std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<uint8_t> {
+  std::vector<std::uint8_t> mosi_data_buffer;
+  std::vector<std::uint8_t> miso_data_buffer(length + 1);
+  mosi_data_buffer.push_back(instruction_word::R_REGISTER | register_address);
+
+  spi_.Transfer(mosi_data_buffer, miso_data_buffer);
+  miso_data_buffer.erase(miso_data_buffer.begin());
+
+  return miso_data_buffer;
+}
+
+auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::uint8_t register_content) -> types::DriverStatus {
+  std::vector<std::uint8_t> mosi_data_buffer;
+  mosi_data_buffer.push_back(instruction_word::W_REGISTER | register_address);
+  mosi_data_buffer.push_back(register_content);
+
+  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+
+  return spi_ret_val;
+}
+
+auto NRF24L01SpiProtocol::WriteRegister(std::uint8_t register_address, std::vector<uint8_t> register_content) -> types::DriverStatus {
+  std::vector<uint8_t> mosi_data_buffer;
+  mosi_data_buffer = register_content;
+  mosi_data_buffer.insert(mosi_data_buffer.begin(), instruction_word::W_REGISTER);
+
+  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+
+  return spi_ret_val;
+}
+
+auto NRF24L01SpiProtocol::WritePayloadData(std::vector<uint8_t> &payload) noexcept -> types::DriverStatus {
+  std::vector<uint8_t> mosi_data_buffer;
+  mosi_data_buffer = payload;
+  mosi_data_buffer.insert(mosi_data_buffer.begin(), instruction_word::W_TX_PAYLOAD);
+
+  auto spi_ret_val = spi_.Write(mosi_data_buffer);
+
+  return spi_ret_val;
+}
+
+}  // namespace com

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -4,6 +4,11 @@
 #include <memory>
 #include "com_nrf24l01_reg.hpp"
 #include "spi.hpp"
+#ifndef UNIT_TEST
+#include "utilities/byte.hpp"
+#else
+#include "byte_mock.hpp"
+#endif
 
 namespace com {
 /**

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -1,6 +1,7 @@
 #ifndef SRC_COM_COM_NRF24L01_SPI_PROTOCOL_HPP_
 #define SRC_COM_COM_NRF24L01_SPI_PROTOCOL_HPP_
 
+#include <memory>
 #include "com_nrf24l01_reg.hpp"
 #include "spi.hpp"
 
@@ -80,7 +81,7 @@ class NRF24L01SpiProtocol final {
    * 
    * @param spi 
    */
-  explicit NRF24L01SpiProtocol(spi::SPI &spi) : spi_(spi){};
+  explicit NRF24L01SpiProtocol(std::unique_ptr<spi::SPI> spi) : spi_(std::move(spi)){};
   NRF24L01SpiProtocol() = delete;
   /**
    * @brief Destroy the NRF24L01SpiProtocol object
@@ -89,7 +90,7 @@ class NRF24L01SpiProtocol final {
   ~NRF24L01SpiProtocol() = default;
 
  private:
-  spi::SPI &spi_;
+  std::unique_ptr<spi::SPI> spi_;
 };
 }  // namespace com
 

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -7,17 +7,17 @@
 namespace com {
 class NRF24L01SpiProtocol {
  public:
-  NRF24L01SpiProtocol(spi::SPI &spi) : spi_(spi){};
+  explicit NRF24L01SpiProtocol(spi::SPI &spi) : spi_(spi){};
   // SPI protocol functions
   auto ReadRegister(std::uint8_t register_address) noexcept -> std::uint8_t;
   auto ReadRegister(std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<std::uint8_t>;
-  auto WriteRegister(std::uint8_t register_address, std::uint8_t register_content) -> types::DriverStatus;
-  auto WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) -> types::DriverStatus;
+  auto WriteRegister(std::uint8_t register_address, std::uint8_t register_content) noexcept -> types::DriverStatus;
+  auto WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) noexcept -> types::DriverStatus;
   auto WritePayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
   auto ReadPayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
   auto FlushTxBuffer() noexcept -> types::DriverStatus;
   auto FlushRxBuffer() noexcept -> types::DriverStatus;
-  auto ReadAndClearIRQFlags() -> register_t;
+  auto ReadAndClearIRQFlags() noexcept -> register_t;
 
  private:
   spi::SPI &spi_;

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -1,6 +1,7 @@
 #ifndef SRC_COM_COM_NRF24L01_SPI_PROTOCOL_HPP_
 #define SRC_COM_COM_NRF24L01_SPI_PROTOCOL_HPP_
 
+#include "com_nrf24l01_reg.hpp"
 #include "spi.hpp"
 
 namespace com {
@@ -9,9 +10,9 @@ class NRF24L01SpiProtocol {
   NRF24L01SpiProtocol(spi::SPI &spi) : spi_(spi){};
   // SPI protocol functions
   auto ReadRegister(std::uint8_t register_address) noexcept -> std::uint8_t;
-  auto ReadRegister(std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<uint8_t>;
+  auto ReadRegister(std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<std::uint8_t>;
   auto WriteRegister(std::uint8_t register_address, std::uint8_t register_content) -> types::DriverStatus;
-  auto WriteRegister(std::uint8_t register_address, std::vector<uint8_t> register_content) -> types::DriverStatus;
+  auto WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) -> types::DriverStatus;
   auto WritePayloadData(std::vector<uint8_t> &payload) noexcept -> types::DriverStatus;
 
  private:

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -5,19 +5,88 @@
 #include "spi.hpp"
 
 namespace com {
-class NRF24L01SpiProtocol {
+/**
+ * @brief Collection of basic operations offered by the NRF24L01 communication device.
+ * 
+ */
+class NRF24L01SpiProtocol final {
  public:
-  explicit NRF24L01SpiProtocol(spi::SPI &spi) : spi_(spi){};
-  // SPI protocol functions
+  /**
+  * @brief Simple single byte register read action.
+  * 
+  * @param register_address Addess of the target register as hex.
+  * @return std::uint8_t Register content as byte.
+  */
+
   auto ReadRegister(std::uint8_t register_address) noexcept -> std::uint8_t;
+  /**
+   * @brief Read multiple byte register.
+   * 
+   * @param register_address Address of the target register as hex.
+   * @param length Number of bytes to read.
+   * @return std::vector<std::uint8_t> Register content as vector of bytes.
+   */
   auto ReadRegister(std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<std::uint8_t>;
+  /**
+   * @brief Simple single byte write action.
+   * 
+   * @param register_address Address of the target register as hex.
+   * @param register_content Register content as byte. The current content will be overwritten.
+   * @return types::DriverStatus 
+   */
   auto WriteRegister(std::uint8_t register_address, std::uint8_t register_content) noexcept -> types::DriverStatus;
+  /**
+   * @brief Write multiple bytes to register.
+   * 
+   * @param register_address Address of the target register as hex.
+   * @param register_content Register content as byte. The current content will be overwritten.
+   * @return types::DriverStatus 
+   */
   auto WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) noexcept -> types::DriverStatus;
+  /**
+   * @brief Write to transmission payload buffer.
+   * 
+   * @param payload Reference to the vector holding payload data that must be transmitted.
+   * @return types::DriverStatus 
+   */
   auto WritePayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
+  /**
+   * @brief Get first level of the rx fifo buffer.
+   * 
+   * @param payload Reference to a vector to which the received payload will be written.
+   * @return types::DriverStatus 
+   */
   auto ReadPayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
+  /**
+   * @brief Flush the transmission buffer on the NRF24L01 device.
+   * 
+   * @return types::DriverStatus 
+   */
   auto FlushTxBuffer() noexcept -> types::DriverStatus;
+  /**
+   * @brief Flush the receive buffer on the NRF24L01 device.
+   * 
+   * @return types::DriverStatus 
+   */
   auto FlushRxBuffer() noexcept -> types::DriverStatus;
+  /**
+   * @brief Get the current content of the status register and clear IRQ related flags.
+   * 
+   * @return register_t Status register content.
+   */
   auto ReadAndClearIRQFlags() noexcept -> register_t;
+  /**
+   * @brief Construct a new NRF24L01SpiProtocol object
+   * 
+   * @param spi 
+   */
+  explicit NRF24L01SpiProtocol(spi::SPI &spi) : spi_(spi){};
+  NRF24L01SpiProtocol() = delete;
+  /**
+   * @brief Destroy the NRF24L01SpiProtocol object
+   * 
+   */
+  ~NRF24L01SpiProtocol() = default;
 
  private:
   spi::SPI &spi_;

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -1,0 +1,22 @@
+#ifndef SRC_COM_COM_NRF24L01_SPI_PROTOCOL_HPP_
+#define SRC_COM_COM_NRF24L01_SPI_PROTOCOL_HPP_
+
+#include "spi.hpp"
+
+namespace com {
+class NRF24L01SpiProtocol {
+ public:
+  NRF24L01SpiProtocol(spi::SPI &spi) : spi_(spi){};
+  // SPI protocol functions
+  auto ReadRegister(std::uint8_t register_address) noexcept -> std::uint8_t;
+  auto ReadRegister(std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<uint8_t>;
+  auto WriteRegister(std::uint8_t register_address, std::uint8_t register_content) -> types::DriverStatus;
+  auto WriteRegister(std::uint8_t register_address, std::vector<uint8_t> register_content) -> types::DriverStatus;
+  auto WritePayloadData(std::vector<uint8_t> &payload) noexcept -> types::DriverStatus;
+
+ private:
+  spi::SPI &spi_;
+};
+}  // namespace com
+
+#endif

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -15,6 +15,9 @@ class NRF24L01SpiProtocol {
   auto WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) -> types::DriverStatus;
   auto WritePayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
   auto ReadPayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
+  auto FlushTxBuffer() noexcept -> types::DriverStatus;
+  auto FlushRxBuffer() noexcept -> types::DriverStatus;
+  auto ReadAndClearIRQFlags() -> register_t;
 
  private:
   spi::SPI &spi_;

--- a/src/com/com_nrf24l01_spi_protocol.hpp
+++ b/src/com/com_nrf24l01_spi_protocol.hpp
@@ -13,7 +13,8 @@ class NRF24L01SpiProtocol {
   auto ReadRegister(std::uint8_t register_address, std::uint8_t length) noexcept -> std::vector<std::uint8_t>;
   auto WriteRegister(std::uint8_t register_address, std::uint8_t register_content) -> types::DriverStatus;
   auto WriteRegister(std::uint8_t register_address, std::vector<std::uint8_t> &register_content) -> types::DriverStatus;
-  auto WritePayloadData(std::vector<uint8_t> &payload) noexcept -> types::DriverStatus;
+  auto WritePayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
+  auto ReadPayloadData(std::vector<std::uint8_t> &payload) noexcept -> types::DriverStatus;
 
  private:
   spi::SPI &spi_;

--- a/tests/com/CMakeLists.txt
+++ b/tests/com/CMakeLists.txt
@@ -21,7 +21,7 @@ add_testpackage(TEST_NAME
 )
 
 add_testpackage(TEST_NAME 
-                    com_nrf24l01_spi_ptotocol 
+                    com_nrf24l01_spi_protocol 
                 SOURCES 
                     com_nrf24l01_spi_protocol_tests.cpp
                     ${CMAKE_SOURCE_DIR}/src/com/com_nrf24l01_spi_protocol.cpp

--- a/tests/com/CMakeLists.txt
+++ b/tests/com/CMakeLists.txt
@@ -19,3 +19,14 @@ add_testpackage(TEST_NAME
                     ${CMAKE_SOURCE_DIR}/src/types
                     ${CMAKE_SOURCE_DIR}/tests/com/mock_libraries
 )
+
+add_testpackage(TEST_NAME 
+                    com_nrf24l01_spi_ptotocol 
+                SOURCES 
+                    com_nrf24l01_spi_protocol_tests.cpp
+                    ${CMAKE_SOURCE_DIR}/src/com/com_nrf24l01_spi_protocol.cpp
+                TEST_INCLUDE_DIRECTORIES 
+                    ${CMAKE_SOURCE_DIR}/src/com
+                    ${CMAKE_SOURCE_DIR}/src/types
+                    ${CMAKE_SOURCE_DIR}/tests/com/mock_libraries
+)

--- a/tests/com/com_nrf24l01_spi_protocol_tests.cpp
+++ b/tests/com/com_nrf24l01_spi_protocol_tests.cpp
@@ -1,0 +1,19 @@
+#include "com_nrf24l01_spi_protocol.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace {
+class ComNRF24L01SpiProtocolTests : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+  spi::CSPinDefinition com_cs_pin_;
+  spi::SPI spi_{com_cs_pin_};
+  com::NRF24L01SpiProtocol unit_under_test_{spi_};
+};
+
+TEST_F(ComNRF24L01SpiProtocolTests, read_register_spi_tx_ok) {
+  ASSERT_TRUE(true);
+}
+
+}  // namespace

--- a/tests/com/com_nrf24l01_spi_protocol_tests.cpp
+++ b/tests/com/com_nrf24l01_spi_protocol_tests.cpp
@@ -11,9 +11,10 @@ namespace {
 class ComNRF24L01SpiProtocolTests : public ::testing::Test {
  protected:
   virtual void SetUp() {
+    spi_ = std::make_unique<spi::SPI>(cs_pin_);
   }
   spi::CSPin cs_pin_;
-  spi::SPI spi_{cs_pin_};
+  std::unique_ptr<spi::SPI> spi_;
   std::unique_ptr<com::NRF24L01SpiProtocol> unit_under_test_;
 };
 
@@ -26,16 +27,16 @@ types::DriverStatus ConstructTestVector(std::vector<std::uint8_t> &mosi, std::ve
 
 TEST_F(ComNRF24L01SpiProtocolTests, read_register) {
   std::uint8_t test_reg_addr = 0xfa;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::R_REGISTER | test_reg_addr), ElementsAre(_, _)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::R_REGISTER | test_reg_addr), ElementsAre(_, _)));
   unit_under_test_->ReadRegister(test_reg_addr);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_ok) {
   std::uint8_t test_reg_addr = 0xfa;
   std::uint8_t test_reg_content = 0xaf;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, test_reg_content)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, test_reg_content)));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
@@ -43,8 +44,8 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_ok) {
 TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_not_ok) {
   std::uint8_t test_reg_addr = 0xfa;
   std::uint8_t test_reg_content = 0xaf;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Write(_)).WillOnce(Return(types::DriverStatus::HAL_ERROR));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Write(_)).WillOnce(Return(types::DriverStatus::HAL_ERROR));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::HAL_ERROR);
 }
@@ -52,24 +53,24 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_not_ok) {
 TEST_F(ComNRF24L01SpiProtocolTests, read_register_multibyte) {
   std::uint8_t test_reg_addr = 0xfa;
   std::uint8_t length = 3;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::R_REGISTER | test_reg_addr), ElementsAre(_, _, _, _)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::R_REGISTER | test_reg_addr), ElementsAre(_, _, _, _)));
   unit_under_test_->ReadRegister(test_reg_addr, length);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_register_multibyte_spi_tx_ok) {
   std::uint8_t test_reg_addr = 0x0a;
   std::vector<std::uint8_t> test_reg_content{0xaf, 0xaf, 0xaf};
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, 0xaf, 0xaf, 0xaf)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, 0xaf, 0xaf, 0xaf)));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_payload_spi_tx_ok) {
   std::vector<std::uint8_t> test_reg_content{0xaf, 0xaf, 0xaf};
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::W_TX_PAYLOAD, 0xaf, 0xaf, 0xaf)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::W_TX_PAYLOAD, 0xaf, 0xaf, 0xaf)));
   auto retval = unit_under_test_->WritePayloadData(test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
@@ -77,29 +78,29 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_payload_spi_tx_ok) {
 TEST_F(ComNRF24L01SpiProtocolTests, read_payload_spi_tx_ok) {
   std::vector<std::uint8_t> test_payload;
   test_payload.resize(4);
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::R_RX_PAYLOAD), _));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::R_RX_PAYLOAD), _));
   auto retval = unit_under_test_->ReadPayloadData(test_payload);
   EXPECT_THAT(test_payload, ElementsAre(_, _, _));
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, flush_tx_buffer) {
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::FLUSH_TX)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::FLUSH_TX)));
   unit_under_test_->FlushTxBuffer();
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, flush_rx_buffer) {
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::FLUSH_RX)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::FLUSH_RX)));
   unit_under_test_->FlushRxBuffer();
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, read_and_clear_irq_flags) {
   std::uint8_t test_reg_addr = com::reg::status::REG_ADDR;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, _), _))
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
+  EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, _), _))
       .WillOnce(Invoke(&ConstructTestVector));
   auto rv = unit_under_test_->ReadAndClearIRQFlags();
   ASSERT_EQ(rv, 0xaa);

--- a/tests/com/com_nrf24l01_spi_protocol_tests.cpp
+++ b/tests/com/com_nrf24l01_spi_protocol_tests.cpp
@@ -60,6 +60,24 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_multibyte_spi_tx_ok) {
   EXPECT_EQ(retval, types::DriverStatus::OK);
 }
 
+TEST_F(ComNRF24L01SpiProtocolTests, write_payload_spi_tx_ok) {
+  std::vector<std::uint8_t> test_reg_content{0xaf, 0xaf, 0xaf};
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
+  EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::W_TX_PAYLOAD, 0xaf, 0xaf, 0xaf)));
+  auto retval = unit_under_test_->WritePayloadData(test_reg_content);
+  EXPECT_EQ(retval, types::DriverStatus::OK);
+}
+
+TEST_F(ComNRF24L01SpiProtocolTests, read_payload_spi_tx_ok) {
+  std::vector<std::uint8_t> test_payload;
+  test_payload.resize(4);
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
+  EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::R_RX_PAYLOAD), _));
+  auto retval = unit_under_test_->ReadPayloadData(test_payload);
+  EXPECT_THAT(test_payload, ElementsAre(_, _, _));
+  EXPECT_EQ(retval, types::DriverStatus::OK);
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/com/com_nrf24l01_spi_protocol_tests.cpp
+++ b/tests/com/com_nrf24l01_spi_protocol_tests.cpp
@@ -98,9 +98,9 @@ TEST_F(ComNRF24L01SpiProtocolTests, flush_rx_buffer) {
 
 TEST_F(ComNRF24L01SpiProtocolTests, read_and_clear_irq_flags) {
   std::uint8_t test_reg_addr = com::reg::status::REG_ADDR;
-  std::uint8_t clear_irq_bit_sequence = 0x70;
   unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
-  EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, _), _)).WillOnce(Invoke(&ConstructTestVector));
+  EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, _), _))
+      .WillOnce(Invoke(&ConstructTestVector));
   auto rv = unit_under_test_->ReadAndClearIRQFlags();
   EXPECT_EQ(rv, 0xaa);
 }

--- a/tests/com/com_nrf24l01_spi_protocol_tests.cpp
+++ b/tests/com/com_nrf24l01_spi_protocol_tests.cpp
@@ -37,7 +37,7 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_ok) {
   unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
   EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, test_reg_content)));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
-  EXPECT_EQ(retval, types::DriverStatus::OK);
+  ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_not_ok) {
@@ -46,7 +46,7 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_not_ok) {
   unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
   EXPECT_CALL(spi_, Write(_)).WillOnce(Return(types::DriverStatus::HAL_ERROR));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
-  EXPECT_EQ(retval, types::DriverStatus::HAL_ERROR);
+  ASSERT_EQ(retval, types::DriverStatus::HAL_ERROR);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, read_register_multibyte) {
@@ -63,7 +63,7 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_multibyte_spi_tx_ok) {
   unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
   EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, 0xaf, 0xaf, 0xaf)));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
-  EXPECT_EQ(retval, types::DriverStatus::OK);
+  ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_payload_spi_tx_ok) {
@@ -71,7 +71,7 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_payload_spi_tx_ok) {
   unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(spi_);
   EXPECT_CALL(spi_, Write(ElementsAre(com::instruction_word::W_TX_PAYLOAD, 0xaf, 0xaf, 0xaf)));
   auto retval = unit_under_test_->WritePayloadData(test_reg_content);
-  EXPECT_EQ(retval, types::DriverStatus::OK);
+  ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, read_payload_spi_tx_ok) {
@@ -81,7 +81,7 @@ TEST_F(ComNRF24L01SpiProtocolTests, read_payload_spi_tx_ok) {
   EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::R_RX_PAYLOAD), _));
   auto retval = unit_under_test_->ReadPayloadData(test_payload);
   EXPECT_THAT(test_payload, ElementsAre(_, _, _));
-  EXPECT_EQ(retval, types::DriverStatus::OK);
+  ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, flush_tx_buffer) {
@@ -102,7 +102,7 @@ TEST_F(ComNRF24L01SpiProtocolTests, read_and_clear_irq_flags) {
   EXPECT_CALL(spi_, Transfer(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, _), _))
       .WillOnce(Invoke(&ConstructTestVector));
   auto rv = unit_under_test_->ReadAndClearIRQFlags();
-  EXPECT_EQ(rv, 0xaa);
+  ASSERT_EQ(rv, 0xaa);
 }
 
 int main(int argc, char **argv) {

--- a/tests/com/com_nrf24l01_spi_protocol_tests.cpp
+++ b/tests/com/com_nrf24l01_spi_protocol_tests.cpp
@@ -5,13 +5,14 @@
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::Invoke;
+using ::testing::NiceMock;
 using ::testing::Return;
 
 namespace {
 class ComNRF24L01SpiProtocolTests : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    spi_ = std::make_unique<spi::SPI>(cs_pin_);
+    spi_ = std::make_unique<NiceMock<spi::SPI>>(cs_pin_);
   }
   spi::CSPin cs_pin_;
   std::unique_ptr<spi::SPI> spi_;
@@ -27,16 +28,16 @@ types::DriverStatus ConstructTestVector(std::vector<std::uint8_t> &mosi, std::ve
 
 TEST_F(ComNRF24L01SpiProtocolTests, read_register) {
   std::uint8_t test_reg_addr = 0xfa;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::R_REGISTER | test_reg_addr), ElementsAre(_, _)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   unit_under_test_->ReadRegister(test_reg_addr);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_ok) {
   std::uint8_t test_reg_addr = 0xfa;
   std::uint8_t test_reg_content = 0xaf;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, test_reg_content)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
@@ -44,8 +45,8 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_ok) {
 TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_not_ok) {
   std::uint8_t test_reg_addr = 0xfa;
   std::uint8_t test_reg_content = 0xaf;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Write(_)).WillOnce(Return(types::DriverStatus::HAL_ERROR));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::HAL_ERROR);
 }
@@ -53,24 +54,24 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_register_spi_tx_not_ok) {
 TEST_F(ComNRF24L01SpiProtocolTests, read_register_multibyte) {
   std::uint8_t test_reg_addr = 0xfa;
   std::uint8_t length = 3;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::R_REGISTER | test_reg_addr), ElementsAre(_, _, _, _)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   unit_under_test_->ReadRegister(test_reg_addr, length);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_register_multibyte_spi_tx_ok) {
   std::uint8_t test_reg_addr = 0x0a;
   std::vector<std::uint8_t> test_reg_content{0xaf, 0xaf, 0xaf};
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, 0xaf, 0xaf, 0xaf)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   auto retval = unit_under_test_->WriteRegister(test_reg_addr, test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, write_payload_spi_tx_ok) {
   std::vector<std::uint8_t> test_reg_content{0xaf, 0xaf, 0xaf};
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::W_TX_PAYLOAD, 0xaf, 0xaf, 0xaf)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   auto retval = unit_under_test_->WritePayloadData(test_reg_content);
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
@@ -78,30 +79,30 @@ TEST_F(ComNRF24L01SpiProtocolTests, write_payload_spi_tx_ok) {
 TEST_F(ComNRF24L01SpiProtocolTests, read_payload_spi_tx_ok) {
   std::vector<std::uint8_t> test_payload;
   test_payload.resize(4);
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::R_RX_PAYLOAD), _));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   auto retval = unit_under_test_->ReadPayloadData(test_payload);
   EXPECT_THAT(test_payload, ElementsAre(_, _, _));
   ASSERT_EQ(retval, types::DriverStatus::OK);
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, flush_tx_buffer) {
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::FLUSH_TX)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   unit_under_test_->FlushTxBuffer();
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, flush_rx_buffer) {
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Write(ElementsAre(com::instruction_word::FLUSH_RX)));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   unit_under_test_->FlushRxBuffer();
 }
 
 TEST_F(ComNRF24L01SpiProtocolTests, read_and_clear_irq_flags) {
   std::uint8_t test_reg_addr = com::reg::status::REG_ADDR;
-  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   EXPECT_CALL(*spi_, Transfer(ElementsAre(com::instruction_word::W_REGISTER | test_reg_addr, _), _))
       .WillOnce(Invoke(&ConstructTestVector));
+  unit_under_test_ = std::make_unique<com::NRF24L01SpiProtocol>(std::move(spi_));
   auto rv = unit_under_test_->ReadAndClearIRQFlags();
   ASSERT_EQ(rv, 0xaa);
 }

--- a/tests/com/mock_libraries/byte_mock.hpp
+++ b/tests/com/mock_libraries/byte_mock.hpp
@@ -10,14 +10,14 @@ namespace utilities {
 
 class Byte {
  public:
-  Byte(std::uint8_t){};
+  explicit Byte(std::uint8_t){};
   MOCK_METHOD(std::uint8_t, Get, (), (noexcept));
   MOCK_METHOD(void, SetBit, (std::uint8_t), (noexcept));
   MOCK_METHOD(void, ClearBit, (std::uint8_t), (noexcept));
   MOCK_METHOD(void, SetLowNibble, (std::uint8_t), (noexcept));
   MOCK_METHOD(void, SetHighNibble, (std::uint8_t), (noexcept));
 
-  std::uint8_t test_member;
+  std::uint8_t test_member = 0;
 };
 }  // namespace utilities
 

--- a/tests/com/mock_libraries/byte_mock.hpp
+++ b/tests/com/mock_libraries/byte_mock.hpp
@@ -1,0 +1,24 @@
+#ifndef TESTS_COM_MOCK_LIBRARIES_BYTE_HPP_
+#define TESTS_COM_MOCK_LIBRARIES_BYTE_HPP_
+
+#include <array>
+#include <queue>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace utilities {
+
+class Byte {
+ public:
+  Byte(std::uint8_t){};
+  MOCK_METHOD(std::uint8_t, Get, (), (noexcept));
+  MOCK_METHOD(void, SetBit, (std::uint8_t), (noexcept));
+  MOCK_METHOD(void, ClearBit, (std::uint8_t), (noexcept));
+  MOCK_METHOD(void, SetLowNibble, (std::uint8_t), (noexcept));
+  MOCK_METHOD(void, SetHighNibble, (std::uint8_t), (noexcept));
+
+  std::uint8_t test_member;
+};
+}  // namespace utilities
+
+#endif

--- a/tests/com/mock_libraries/spi.hpp
+++ b/tests/com/mock_libraries/spi.hpp
@@ -18,7 +18,7 @@ typedef struct CSPinDefinition {
 
 class MockSPI {
  public:
-  MockSPI(const CSPin chip_select){};
+  explicit MockSPI(const CSPin chip_select){};
   MOCK_METHOD(types::DriverStatus, Transfer, (std::vector<uint8_t> & mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer), (noexcept));
   MOCK_METHOD(types::DriverStatus, Write, (std::vector<uint8_t> & mosi_data_buffer), (noexcept));
 };

--- a/tests/com/mock_libraries/spi.hpp
+++ b/tests/com/mock_libraries/spi.hpp
@@ -1,0 +1,28 @@
+#ifndef TESTS_MOCK_LIBRARIES_COM_MOCK_SPI_HPP_
+#define TESTS_MOCK_LIBRARIES_COM_MOCK_SPI_HPP_
+
+#include "error_types.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+typedef struct
+{
+} GPIO_TypeDef;
+
+namespace spi {
+
+typedef struct CSPinDefinition {
+  GPIO_TypeDef *peripheral;
+  uint16_t gpio_pin;
+} CSPin;
+
+class MockSPI {
+ public:
+  MockSPI(const CSPin chip_select){};
+  MOCK_METHOD(types::DriverStatus, Transfer, (std::vector<uint8_t> & mosi_data_buffer, std::vector<uint8_t> &miso_data_buffer), (noexcept));
+  MOCK_METHOD(types::DriverStatus, Write, (std::vector<uint8_t> & mosi_data_buffer), (noexcept));
+};
+
+using SPI = MockSPI;
+}  // namespace spi
+#endif

--- a/tests/com/mock_libraries/stm32g4xx_hal.c
+++ b/tests/com/mock_libraries/stm32g4xx_hal.c
@@ -1,0 +1,3 @@
+#include "stm32g4xx_hal.h"
+
+void HAL_Delay(uint32_t delay) {}

--- a/tests/com/mock_libraries/stm32g4xx_hal.h
+++ b/tests/com/mock_libraries/stm32g4xx_hal.h
@@ -1,0 +1,16 @@
+#ifndef TESTS_MOCK_LIBRARIES_SPI_STM32G4XX_HAL_H_
+#define TESTS_MOCK_LIBRARIES_SPI_STM32G4XX_HAL_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void HAL_Delay(uint32_t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR introduces a seperate protocol layer for the COM SPI interface. It provides access to the basic operations implemented by the NRF24L01 spi interface.

Acceptance criteria:

Unit tests cover 100% and all pass
Unit tests are complete (no logical fallacy is untested and all equivalency classes were tested)
Class diagrams from wiki are not in conflict with implementation
All automatic checks pass
Google Styleguide was followed
Additional guidelines from the wiki were followed
No logical errors in code
All error return values are always checked

Closes #306