### PR TITLE
COM NRF24L01 test harness update

### DIFF
--- a/tests/com/CMakeLists.txt
+++ b/tests/com/CMakeLists.txt
@@ -75,3 +75,13 @@ add_testpackage(TEST_NAME
                     ${CMAKE_SOURCE_DIR}/src/types
                     ${CMAKE_SOURCE_DIR}/tests/com/mock_libraries
 )
+
+add_testpackage(TEST_NAME 
+                    com_data_packet
+                SOURCES
+                    com_data_packet_tests.cpp
+                TEST_INCLUDE_DIRECTORIES
+                    ${CMAKE_SOURCE_DIR}/src/com
+                    ${CMAKE_SOURCE_DIR}/src/types
+                    ${CMAKE_SOURCE_DIR}/tests/com/mock_libraries
+)

--- a/tests/com/com_data_packet_tests.cpp
+++ b/tests/com/com_data_packet_tests.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "com_types.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -14,15 +15,28 @@ class ComDataPacketTests : public ::testing::Test {
     packet.target = types::PutDataTarget::TARGET_GROUND_CONTROL;
     std::vector<std::uint8_t> mock_data(30, 0xAA);
     packet.data = mock_data;
+    frame.resize(32);
+    std::fill(frame.begin(), frame.end(), 0xaa);
+    frame.at(0) = static_cast<std::uint8_t>(types::ComPacketType::TELEMETRY_PACKET);
+    frame.at(1) = static_cast<std::uint8_t>(types::PutDataTarget::TARGET_GROUND_CONTROL);
   }
   types::ComDataPacket packet;
+  types::com_msg_frame frame;
 };
 
 TEST_F(ComDataPacketTests, serialize_packet) {
-  ASSERT_EQ(return_value, msg_frame);
+  auto return_value = packet.Serialize();
+
+  ASSERT_EQ(return_value, frame);
 }
 
 TEST_F(ComDataPacketTests, deserialize_packet) {
+  types::ComDataPacket test_packet;
+  test_packet.Deserialize(frame);
+
+  ASSERT_EQ(test_packet.type, packet.type);
+  ASSERT_EQ(test_packet.target, packet.target);
+  ASSERT_EQ(test_packet.data, packet.data);
 }
 
 }  // namespace


### PR DESCRIPTION
Addition to unit test harness was necessary. Tests now cover Serialize and Deserialize functions of ComDataPacket class.

Fixes #344