### PR TITLE
Increased the resolution of speed control by 10x

### DIFF
--- a/src/propulsion/esc.hpp
+++ b/src/propulsion/esc.hpp
@@ -60,7 +60,7 @@ class Esc {
    * @return A types::DriverStatus type confirmation whether it was working or not
    * 
    */
-  virtual auto SetPulseDuration(int pulse_duration, int repetition_period) noexcept -> const types::DriverStatus = 0;
+  virtual auto SetPulseDuration(const float pulse_duration, int repetition_period) noexcept -> const types::DriverStatus = 0;
 
  protected:
   /**

--- a/src/propulsion/letodar_2204.cpp
+++ b/src/propulsion/letodar_2204.cpp
@@ -17,7 +17,7 @@ auto LeTodar2204::SetSpeedInPercent(const float speed) noexcept -> types::Driver
     auto min_pulse_duration = esc_->GetMinPulseDurationInMicroSeconds();
     auto one_percent_in_ms = (max_pulse_duration - min_pulse_duration) / PERCENTAGE_FACTOR;
     auto speed_in_ms_pulse_duration = min_pulse_duration + (speed * one_percent_in_ms);
-    auto set_pulse_error = esc_->SetPulseDuration(static_cast<int>(speed_in_ms_pulse_duration), REPETITION_TIME_IN_MS);
+    auto set_pulse_error = esc_->SetPulseDuration(speed_in_ms_pulse_duration, REPETITION_TIME_IN_MS);
     if (set_pulse_error != types::DriverStatus::OK) {
       return types::DriverStatus::HAL_ERROR;
     } else {

--- a/src/propulsion/little_bee_20_a.cpp
+++ b/src/propulsion/little_bee_20_a.cpp
@@ -3,13 +3,13 @@
 
 namespace propulsion {
 
-auto LittleBee20A::SetPulseDuration(int pulse_duration, int repetition_period) noexcept -> const types::DriverStatus {
+auto LittleBee20A::SetPulseDuration(const float pulse_duration, int repetition_period) noexcept -> const types::DriverStatus {
   types::DriverStatus error_state;
   const bool pulse_limit_breach =
       pulse_duration > ONESHOT_125_MAX_PULSE_DURATION_IN_US_ ||
       pulse_duration < ONESHOT_125_MIN_PULSE_DURATION_IN_US_;
   const bool period_limit_breach =
-      repetition_period < pulse_duration ||
+      repetition_period < static_cast<int>(pulse_duration) ||
       repetition_period > MAX_REPETITION_PERIOD_;
   if (pulse_limit_breach || period_limit_breach) {
     return types::DriverStatus::INPUT_ERROR;

--- a/src/propulsion/little_bee_20_a.hpp
+++ b/src/propulsion/little_bee_20_a.hpp
@@ -63,11 +63,11 @@ class LittleBee20A final : public Esc {
    *         types::DriverStatus::HAL_ERROR if timer config didn't work
    * 
    */
-  auto SetPulseDuration(int pulse_duration, int repetition_period) noexcept -> const types::DriverStatus override;
+  auto SetPulseDuration(const float pulse_duration, int repetition_period) noexcept -> const types::DriverStatus override;
 
  private:
-  static constexpr auto ONESHOT_125_MAX_PULSE_DURATION_IN_US_ = 250;
-  static constexpr auto ONESHOT_125_MIN_PULSE_DURATION_IN_US_ = 125;
+  static constexpr auto ONESHOT_125_MAX_PULSE_DURATION_IN_US_ = 250.0;
+  static constexpr auto ONESHOT_125_MIN_PULSE_DURATION_IN_US_ = 125.0;
   static constexpr auto MAX_REPETITION_PERIOD_ = 20000;
   static constexpr auto TARGET_TIMER_CLOCK_RATE_ = 10000000;
   static constexpr auto MICROSECONDS_PER_SECOND_ = 1000000;

--- a/tests/propulsion/mock_libraries/esc_mock.hpp
+++ b/tests/propulsion/mock_libraries/esc_mock.hpp
@@ -12,7 +12,7 @@ class MockEsc : public propulsion::Esc {
   MockEsc(TIM_HandleTypeDef* timer, std::uint32_t channel) : Esc(nullptr, 0) {}
   MOCK_METHOD(const int, GetMaxPulseDurationInMicroSeconds, (), (const, noexcept, override));
   MOCK_METHOD(const int, GetMinPulseDurationInMicroSeconds, (), (const, noexcept, override));
-  MOCK_METHOD(const types::DriverStatus, SetPulseDuration, (int pulse_duration, int repetition_period), (noexcept, override));
+  MOCK_METHOD(const types::DriverStatus, SetPulseDuration, (const float pulse_duration, int repetition_period), (noexcept, override));
 };
 
 #endif


### PR DESCRIPTION
Changed type to gain a larger resolution. 

Now the resolution is only restricted by the conversion factor from ms to timer ticks. This can still be increased, but not as trivial as this, so it will only be done if actually needed

Closes #348 